### PR TITLE
Change order of install for nodejs and npm when using make_install=>false

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -155,7 +155,10 @@ define nodejs::install (
       source             => 'https://npmjs.org/install.sh',
       nocheckcertificate => true,
       destination        => "${::nodejs::params::install_dir}/install.sh",
-      require            => File["nodejs-symlink-bin-${node_version}"]
+      require            => [
+        File["nodejs-symlink-bin-${node_version}"],
+        Exec["nodejs-unpack-${node_version}"],
+      ],
     }
 
     exec { "npm-install-${node_version}":


### PR DESCRIPTION
npm tries to install prior to nodejs

```
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/File[nodejs-symlink-bin-with-version-v0.10.20]/ensure: created
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/File[nodejs-symlink-bin-v0.10.20]/ensure: created
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/Exec[npm-install-v0.10.20]/returns: npm cannot be installed without nodejs.
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/Exec[npm-install-v0.10.20]/returns: Install node first, and then try again.
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/Exec[npm-install-v0.10.20]/returns: 
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/Exec[npm-install-v0.10.20]/returns: Maybe node is installed, but not in the PATH?
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/Exec[npm-install-v0.10.20]/returns: Note that running as sudo can change envs.
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/Exec[npm-install-v0.10.20]/returns: 
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/Exec[npm-install-v0.10.20]/returns: PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
Error: sh install.sh returned 1 instead of one of [0]
Error: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/Exec[npm-install-v0.10.20]/returns: change from notrun to 0 failed: sh install.sh returned 1 instead of one of [0]
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/File[npm-symlink-v0.10.20]: Dependency Exec[npm-install-v0.10.20] has failures: true
Warning: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/File[npm-symlink-v0.10.20]: Skipping because of failed dependencies
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/Wget::Fetch[nodejs-download-v0.10.20]/Exec[wget-nodejs-download-v0.10.20]/returns: executed successfully
Notice: /Stage[main]/Nodejs/Nodejs::Install[nodejs-v0.10.20]/Exec[nodejs-unpack-v0.10.20]/returns: executed successfully
```
