### PR TITLE
just install npm for nodejs below v0.6.3

### DIFF
--- a/lib/puppet/parser/functions/is_npm_provided.rb
+++ b/lib/puppet/parser/functions/is_npm_provided.rb
@@ -1,0 +1,12 @@
+require 'semver'
+
+module Puppet::Parser::Functions
+  newfunction(:is_npm_provided, :type => :rvalue) do |args|
+
+    # since version v0.6.3 npm is provided via nodejs
+    nodeProvidesNpmVersion = SemVer.new('v0.6.3')
+    currentVersion = SemVer.new(args[0]);
+
+    (currentVersion >= nodeProvidesNpmVersion)
+  end
+end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -58,6 +58,12 @@ define nodejs::install (
 
   ensure_packages([ 'tar', 'curl' ])
 
+  package { 'semver':
+    ensure   => installed,
+    provider => gem,
+    before   => File["nodejs-symlink-bin-${node_version}"],
+  }
+
   if $make_install {
     $node_filename       = "node-${node_version}.tar.gz"
     $node_unpack_folder  = "${::nodejs::params::install_dir}/node-${node_version}"
@@ -150,7 +156,9 @@ define nodejs::install (
     target  => $node_symlink_target,
   }
 
-  if ($with_npm) {
+  # automatic installation of npm is introduced since nodejs v0.6.3
+  # so we just install npm for nodejs below v0.6.3
+  if ($with_npm and !is_npm_provided($node_version)) {
     wget::fetch { "npm-download-${node_version}":
       source             => 'https://npmjs.org/install.sh',
       nocheckcertificate => true,

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -3,55 +3,55 @@ require 'spec_helper'
 describe 'nodejs', :type => :class do
   let(:title) { 'nodejs' }
   let(:facts) {{
-    :nodejs_stable_version => 'stable'
+    :nodejs_stable_version => 'v0.10.20'
   }}
 
-  it { should contain_file('nodejs-install-dir-stable') \
+  it { should contain_file('nodejs-install-dir-v0.10.20') \
     .with_ensure('directory') \
     .with_path('/usr/local/node')
   }
 
-  it { should contain_wget__fetch('nodejs-download-stable') \
-    .with_source('http://nodejs.org/dist/stable/node-stable.tar.gz') \
-    .with_destination('/usr/local/node/node-stable.tar.gz')
+  it { should contain_wget__fetch('nodejs-download-v0.10.20') \
+    .with_source('http://nodejs.org/dist/v0.10.20/node-v0.10.20.tar.gz') \
+    .with_destination('/usr/local/node/node-v0.10.20.tar.gz')
   }
 
-  it { should contain_file('nodejs-check-tar-stable') \
+  it { should contain_file('nodejs-check-tar-v0.10.20') \
     .with_ensure('file') \
-    .with_path('/usr/local/node/node-stable.tar.gz')
+    .with_path('/usr/local/node/node-v0.10.20.tar.gz')
   }
 
-  it { should contain_exec('nodejs-unpack-stable') \
-    .with_command('tar xzvf node-stable.tar.gz') \
+  it { should contain_exec('nodejs-unpack-v0.10.20') \
+    .with_command('tar xzvf node-v0.10.20.tar.gz') \
     .with_cwd('/usr/local/node') \
-    .with_unless('test -d /usr/local/node/node-stable')
+    .with_unless('test -d /usr/local/node/node-v0.10.20')
   }
 
-  it { should contain_file('nodejs-check-unpack-stable') \
+  it { should contain_file('nodejs-check-unpack-v0.10.20') \
     .with_ensure('directory') \
-    .with_path('/usr/local/node/node-stable')
+    .with_path('/usr/local/node/node-v0.10.20')
   }
 
-  it { should contain_exec('nodejs-make-install-stable') \
+  it { should contain_exec('nodejs-make-install-v0.10.20') \
     .with_command('python configure && make install') \
-    .with_cwd('/usr/local/node/node-stable') \
-    .with_unless('test -f /usr/local/node/node-stable/node')
+    .with_cwd('/usr/local/node/node-v0.10.20') \
+    .with_unless('test -f /usr/local/node/node-v0.10.20/node') 
   }
 
-  it { should contain_file('nodejs-symlink-bin-stable') \
+  it { should contain_file('nodejs-symlink-bin-v0.10.20') \
     .with_ensure('link') \
     .with_path('/usr/local/bin/node') \
-    .with_target('/usr/local/node/node-stable/node')
+    .with_target('/usr/local/node/node-v0.10.20/node')
   }
 
-  it { should contain_file('nodejs-symlink-bin-with-version-stable') \
+  it { should contain_file('nodejs-symlink-bin-with-version-v0.10.20') \
     .with_ensure('link') \
-    .with_path('/usr/local/bin/node-stable') \
-    .with_target('/usr/local/node/node-stable/node')
+    .with_path('/usr/local/bin/node-v0.10.20') \
+    .with_target('/usr/local/node/node-v0.10.20/node')
   }
 
-  it { should contain_wget__fetch('npm-download-stable') }
-  it { should contain_exec('npm-install-stable') }
+  it { should_not contain_wget__fetch('npm-download-v0.10.20') }
+  it { should_not contain_exec('npm-install-v0.10.20') }
 
   describe 'with a given version' do
     let(:params) {{ :version => 'v0.8.0' }}
@@ -94,30 +94,30 @@ describe 'nodejs', :type => :class do
       .with_target('/usr/local/node/node-v0.8.0/node')
     }
 
-    it { should contain_wget__fetch('npm-download-v0.8.0') }
-    it { should contain_exec('npm-install-v0.8.0') }
+    it { should_not contain_wget__fetch('npm-download-v0.8.0') }
+    it { should_not contain_exec('npm-install-v0.8.0') }
   end
 
   describe 'with a given target_dir' do
     let(:params) {{ :target_dir => '/bin' }}
 
-    it { should contain_file('nodejs-symlink-bin-stable') \
+    it { should contain_file('nodejs-symlink-bin-v0.10.20') \
       .with_ensure('link') \
       .with_path('/bin/node') \
-      .with_target('/usr/local/node/node-stable/node')
+      .with_target('/usr/local/node/node-v0.10.20/node')
     }
   end
 
   describe 'without NPM' do
     let(:params) {{ :with_npm => false }}
 
-    it { should_not contain_exec('npm-download-stable') }
-    it { should_not contain_exec('npm-install-stable') }
+    it { should_not contain_exec('npm-download-v0.10.20') }
+    it { should_not contain_exec('npm-install-v0.10.20') }
   end
 
   describe 'with make_install = false' do
     let(:params) {{ :make_install => false }}
 
-    it { should_not contain_exec('nodejs-make-install-stable') }
+    it { should_not contain_exec('nodejs-make-install-v0.10.20') }
   end
 end

--- a/spec/defines/nodejs_install_spec.rb
+++ b/spec/defines/nodejs_install_spec.rb
@@ -3,43 +3,43 @@ require 'spec_helper'
 describe 'nodejs::install', :type => :define do
   let(:title) { 'nodejs::install' }
   let(:facts) {{
-    :nodejs_stable_version => 'stable'
+    :nodejs_stable_version => 'v0.10.20'
   }}
 
-  it { should contain_file('nodejs-install-dir-stable').with_ensure('directory') }
+  it { should contain_file('nodejs-install-dir-v0.10.20').with_ensure('directory') }
 
-  it { should contain_wget__fetch('nodejs-download-stable') \
-    .with_source('http://nodejs.org/dist/stable/node-stable.tar.gz') \
-    .with_destination('/usr/local/node/node-stable.tar.gz')
+  it { should contain_wget__fetch('nodejs-download-v0.10.20') \
+    .with_source('http://nodejs.org/dist/v0.10.20/node-v0.10.20.tar.gz') \
+    .with_destination('/usr/local/node/node-v0.10.20.tar.gz')
   }
 
-  it { should contain_file('nodejs-check-tar-stable') \
+  it { should contain_file('nodejs-check-tar-v0.10.20') \
     .with_ensure('file') \
-    .with_path('/usr/local/node/node-stable.tar.gz')
+    .with_path('/usr/local/node/node-v0.10.20.tar.gz')
   }
 
-  it { should contain_exec('nodejs-unpack-stable') \
-    .with_command('tar xzvf node-stable.tar.gz') \
+  it { should contain_exec('nodejs-unpack-v0.10.20') \
+    .with_command('tar xzvf node-v0.10.20.tar.gz') \
     .with_cwd('/usr/local/node') \
-    .with_unless('test -d /usr/local/node/node-stable')
+    .with_unless('test -d /usr/local/node/node-v0.10.20')
   }
 
-  it { should contain_file('nodejs-check-unpack-stable') \
+  it { should contain_file('nodejs-check-unpack-v0.10.20') \
     .with_ensure('directory') \
-    .with_path('/usr/local/node/node-stable')
+    .with_path('/usr/local/node/node-v0.10.20')
   }
 
-  it { should contain_exec('nodejs-make-install-stable') \
-    .with_cwd('/usr/local/node/node-stable') \
-    .with_unless('test -f /usr/local/node/node-stable/node')
+  it { should contain_exec('nodejs-make-install-v0.10.20') \
+    .with_cwd('/usr/local/node/node-v0.10.20') \
+    .with_unless('test -f /usr/local/node/node-v0.10.20/node')
   }
 
-  it { should contain_file('nodejs-symlink-bin-stable') \
+  it { should contain_file('nodejs-symlink-bin-v0.10.20') \
     .with_ensure('link') \
     .with_path('/usr/local/bin/node') \
-    .with_target('/usr/local/node/node-stable/node')
+    .with_target('/usr/local/node/node-v0.10.20/node')
   }
 
-  it { should contain_wget__fetch('npm-download-stable') }
-  it { should contain_exec('npm-install-stable') }
+  it { should_not contain_wget__fetch('npm-download-v0.10.20') }
+  it { should_not contain_exec('npm-install-v0.10.20') }
 end

--- a/spec/functions/is_npm_provided_spec.rb
+++ b/spec/functions/is_npm_provided_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'is_npm_provided' do
+  it { should run.with_params('v0.6.4').and_return(true) }
+  it { should run.with_params('v0.6.3').and_return(true) }
+  it { should run.with_params('v0.6.2').and_return(false) }
+end
+


### PR DESCRIPTION
since nodejs v0.6.3 npm is provided via nodejs installation. so it's not required anymore to install npm separately

added tests for is_npm_provided function

:nodejs_stable_version => 'stable' is not a valid version any more. the version stored in facter is expected to be semver.org compatible one
