### PR TITLE
run ./configure instead of python configure

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -122,8 +122,8 @@ define nodejs::install (
     ensure_packages([ 'python', 'g++', 'make' ])
 
     exec { "nodejs-make-install-${node_version}":
-      command => 'python configure && make install',
-      path    => '/usr/bin:/bin:/usr/sbin:/sbin',
+      command => './configure && make && make install',
+      path    => "${node_unpack_folder}:/usr/bin:/bin:/usr/sbin:/sbin",
       cwd     => $node_unpack_folder,
       user    => 'root',
       unless  => "test -f ${node_symlink_target}",

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -33,7 +33,8 @@ describe 'nodejs', :type => :class do
   }
 
   it { should contain_exec('nodejs-make-install-stable') \
-    .with_command('python configure && make install') \
+    .with_command('./configure && make && make install') \
+    .with_path('/usr/local/node/node-stable:/usr/bin:/bin:/usr/sbin:/sbin') \
     .with_cwd('/usr/local/node/node-stable') \
     .with_unless('test -f /usr/local/node/node-stable/node')
   }


### PR DESCRIPTION
some versions of nodejs are using shell configure scripts - so all of them are failing because python is the wrong caller here.
