### PR TITLE
dropped broken npm symlink

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -178,12 +178,5 @@ define nodejs::install (
         Package['curl'],
       ],
     }
-
-    file { "npm-symlink-${node_version}":
-      ensure  => 'link',
-      path    => "${node_target_dir}/npm",
-      target  => "${node_unpack_folder}/bin/npm",
-      require => Exec["npm-install-${node_version}"],
-    }
   }
 }


### PR DESCRIPTION
installing npm via install.sh script results in installing npm into
/usr/local/lib/node_modules/npm instead of /usr/local/node/node-
${node_version} which breaks the symlink
