### PR TITLE
added real support for multiple installed versions of nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ class { 'nodejs':
 ```
 
 By default, this module creates symlinks for each Node.js version installed into
-`/usr/local/bin`. You can change this behavior by using the `target_dir`
-parameter.
+`/usr/local/bin`. A nodejs::install define creates a versioned symlink like `/usr/local/bin/node-v0.10.17`. The class `nodejs` creates the default symlink `/usr/local/bin/node`. You can change this behavior by using the `target_dir` parameter.
 
 Also, this module installs [NPM](https://npmjs.org/) by default. You can set the
 `with_npm` parameter to `false` to not install it.
@@ -118,6 +117,9 @@ Run the following command:
 
     BUNDLE_GEMFILE=.gemfile bundle exec rake test
 
+Known Limitations
+-----------------
+* Just a single nodejs::install define of versions below v0.6.3 is supported!
 
 License
 -------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,8 +23,8 @@
 #  }
 #
 class nodejs (
-  $version      = undef,
-  $target_dir   = undef,
+  $version      = 'stable',
+  $target_dir   = '/usr/local/bin',
   $with_npm     = true,
   $make_install = true,
 ) {
@@ -35,4 +35,25 @@ class nodejs (
     with_npm      => $with_npm,
     make_install  => $make_install,
   }
+
+  $node_version = $version ? {
+    undef     => $::nodejs_stable_version,
+    'stable'  => $::nodejs_stable_version,
+    'latest'  => $::nodejs_latest_version,
+    default   => $version
+  }
+
+  $symlink_target = "/usr/local/node/node-${$node_version}/bin/node"
+
+  $node_binary = $target_dir ? {
+    undef   => '/usr/local/bin/node',
+    default => "${target_dir}/node"
+  }
+
+  file { $node_binary:
+    ensure  => 'link',
+    target  => $symlink_target,
+  }
+
+  # TODO handle default npm symlink
 }

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -2,122 +2,72 @@ require 'spec_helper'
 
 describe 'nodejs', :type => :class do
   let(:title) { 'nodejs' }
+
   let(:facts) {{
     :nodejs_stable_version => 'v0.10.20'
   }}
 
-  it { should contain_file('nodejs-install-dir-v0.10.20') \
-    .with_ensure('directory') \
-    .with_path('/usr/local/node')
-  }
+  describe 'with default parameters' do
+    it { should contain_nodejs__install('nodejs-stable') \
+      .with_version('stable') \
+      .with_target_dir('/usr/local/bin') \
+      .with_with_npm('true') \
+      .with_make_install('true')
+    }
 
-  it { should contain_wget__fetch('nodejs-download-v0.10.20') \
-    .with_source('http://nodejs.org/dist/v0.10.20/node-v0.10.20.tar.gz') \
-    .with_destination('/usr/local/node/node-v0.10.20.tar.gz')
-  }
-
-  it { should contain_file('nodejs-check-tar-v0.10.20') \
-    .with_ensure('file') \
-    .with_path('/usr/local/node/node-v0.10.20.tar.gz')
-  }
-
-  it { should contain_exec('nodejs-unpack-v0.10.20') \
-    .with_command('tar xzvf node-v0.10.20.tar.gz') \
-    .with_cwd('/usr/local/node') \
-    .with_unless('test -d /usr/local/node/node-v0.10.20')
-  }
-
-  it { should contain_file('nodejs-check-unpack-v0.10.20') \
-    .with_ensure('directory') \
-    .with_path('/usr/local/node/node-v0.10.20')
-  }
-
-  it { should contain_exec('nodejs-make-install-v0.10.20') \
-    .with_command('./configure && make && make install') \
-    .with_cwd('/usr/local/node/node-v0.10.20') \
-    .with_unless('test -f /usr/local/node/node-v0.10.20/node')
-  }
-
-  it { should contain_file('nodejs-symlink-bin-v0.10.20') \
-    .with_ensure('link') \
-    .with_path('/usr/local/bin/node') \
-    .with_target('/usr/local/node/node-v0.10.20/node')
-  }
-
-  it { should contain_file('nodejs-symlink-bin-with-version-v0.10.20') \
-    .with_ensure('link') \
-    .with_path('/usr/local/bin/node-v0.10.20') \
-    .with_target('/usr/local/node/node-v0.10.20/node')
-  }
-
-  it { should_not contain_wget__fetch('npm-download-v0.10.20') }
-  it { should_not contain_exec('npm-install-v0.10.20') }
+    it { should contain_file('/usr/local/bin/node') \
+      .with_ensure('link') \
+      .with_target('/usr/local/node/node-v0.10.20/bin/node')
+    }
+  end
 
   describe 'with a given version' do
-    let(:params) {{ :version => 'v0.8.0' }}
+    let(:params) {{
+      :version  => 'v0.10.0',
+    }}
 
-    it { should contain_wget__fetch('nodejs-download-v0.8.0') \
-      .with_source('http://nodejs.org/dist/v0.8.0/node-v0.8.0.tar.gz') \
-      .with_destination('/usr/local/node/node-v0.8.0.tar.gz')
+    it { should contain_nodejs__install('nodejs-v0.10.0') \
+      .with_version('v0.10.0')
     }
 
-    it { should contain_file('nodejs-check-tar-v0.8.0') \
-      .with_ensure('file') \
-      .with_path('/usr/local/node/node-v0.8.0.tar.gz')
-    }
-
-    it { should contain_exec('nodejs-unpack-v0.8.0') \
-      .with_command('tar xzvf node-v0.8.0.tar.gz') \
-      .with_cwd('/usr/local/node') \
-      .with_unless('test -d /usr/local/node/node-v0.8.0')
-    }
-
-    it { should contain_file('nodejs-check-unpack-v0.8.0') \
-      .with_ensure('directory') \
-      .with_path('/usr/local/node/node-v0.8.0')
-    }
-
-    it { should contain_exec('nodejs-make-install-v0.8.0') \
-      .with_cwd('/usr/local/node/node-v0.8.0') \
-      .with_unless('test -f /usr/local/node/node-v0.8.0/node')
-    }
-
-    it { should contain_file('nodejs-symlink-bin-v0.8.0') \
+    it { should contain_file('/usr/local/bin/node') \
       .with_ensure('link') \
-      .with_path('/usr/local/bin/node') \
-      .with_target('/usr/local/node/node-v0.8.0/node')
+      .with_target('/usr/local/node/node-v0.10.0/bin/node')
     }
-
-    it { should contain_file('nodejs-symlink-bin-with-version-v0.8.0') \
-      .with_ensure('link') \
-      .with_path('/usr/local/bin/node-v0.8.0') \
-      .with_target('/usr/local/node/node-v0.8.0/node')
-    }
-
-    it { should_not contain_wget__fetch('npm-download-v0.8.0') }
-    it { should_not contain_exec('npm-install-v0.8.0') }
   end
 
   describe 'with a given target_dir' do
-    let(:params) {{ :target_dir => '/bin' }}
+    let(:params) {{
+      :target_dir  => '/bin',
+    }}
 
-    it { should contain_file('nodejs-symlink-bin-v0.10.20') \
+    it { should contain_nodejs__install('nodejs-stable') \
+      .with_target_dir('/bin') \
+    }
+  
+    it { should contain_file('/bin/node') \
       .with_ensure('link') \
-      .with_path('/bin/node') \
-      .with_target('/usr/local/node/node-v0.10.20/node')
+      .with_target('/usr/local/node/node-v0.10.20/bin/node')
     }
   end
 
   describe 'without NPM' do
-    let(:params) {{ :with_npm => false }}
+    let(:params) {{
+      :with_npm => false
+    }}
 
-    it { should_not contain_exec('npm-download-v0.10.20') }
-    it { should_not contain_exec('npm-install-v0.10.20') }
+    it { should contain_nodejs__install('nodejs-stable') \
+      .with_with_npm('false')
+    }
   end
 
   describe 'with make_install = false' do
-    let(:params) {{ :make_install => false }}
+    let(:params) {{
+      :make_install => false
+    }}
 
-    it { should_not contain_exec('nodejs-make-install-v0.10.20') }
+    it { should contain_nodejs__install('nodejs-stable') \
+      .with_make_install('false')
+    }
   end
 end

--- a/spec/defines/nodejs_install_spec.rb
+++ b/spec/defines/nodejs_install_spec.rb
@@ -6,40 +6,129 @@ describe 'nodejs::install', :type => :define do
     :nodejs_stable_version => 'v0.10.20'
   }}
 
-  it { should contain_file('nodejs-install-dir-v0.10.20').with_ensure('directory') }
+  describe 'with default parameters' do
+    
+    let(:params) {{ }}
 
-  it { should contain_wget__fetch('nodejs-download-v0.10.20') \
-    .with_source('http://nodejs.org/dist/v0.10.20/node-v0.10.20.tar.gz') \
-    .with_destination('/usr/local/node/node-v0.10.20.tar.gz')
-  }
+    it { should contain_file('nodejs-install-dir') \
+      .with_ensure('directory')
+    }
 
-  it { should contain_file('nodejs-check-tar-v0.10.20') \
-    .with_ensure('file') \
-    .with_path('/usr/local/node/node-v0.10.20.tar.gz')
-  }
+    it { should contain_wget__fetch('nodejs-download-v0.10.20') \
+      .with_source('http://nodejs.org/dist/v0.10.20/node-v0.10.20.tar.gz') \
+      .with_destination('/usr/local/node/node-v0.10.20.tar.gz')
+    }
 
-  it { should contain_exec('nodejs-unpack-v0.10.20') \
-    .with_command('tar xzvf node-v0.10.20.tar.gz') \
-    .with_cwd('/usr/local/node') \
-    .with_unless('test -d /usr/local/node/node-v0.10.20')
-  }
+    it { should contain_file('nodejs-check-tar-v0.10.20') \
+      .with_ensure('file') \
+      .with_path('/usr/local/node/node-v0.10.20.tar.gz')
+    }
 
-  it { should contain_file('nodejs-check-unpack-v0.10.20') \
-    .with_ensure('directory') \
-    .with_path('/usr/local/node/node-v0.10.20')
-  }
+    it { should contain_exec('nodejs-unpack-v0.10.20') \
+      .with_command('tar -xzvf node-v0.10.20.tar.gz -C /usr/local/node/node-v0.10.20 --strip-components=1') \
+      .with_cwd('/usr/local/node') \
+      .with_unless('test -f /usr/local/node/node-v0.10.20/bin/node')
+    }
 
-  it { should contain_exec('nodejs-make-install-v0.10.20') \
-    .with_cwd('/usr/local/node/node-v0.10.20') \
-    .with_unless('test -f /usr/local/node/node-v0.10.20/node')
-  }
+    it { should contain_file('/usr/local/node/node-v0.10.20') \
+      .with_ensure('directory')
+    }
 
-  it { should contain_file('nodejs-symlink-bin-v0.10.20') \
-    .with_ensure('link') \
-    .with_path('/usr/local/bin/node') \
-    .with_target('/usr/local/node/node-v0.10.20/node')
-  }
+    it { should contain_exec('nodejs-make-install-v0.10.20') \
+      .with_command('./configure --prefix=/usr/local/node/node-v0.10.20 && make && make install') \
+      .with_cwd('/usr/local/node/node-v0.10.20') \
+      .with_unless('test -f /usr/local/node/node-v0.10.20/bin/node')
+    }
 
-  it { should_not contain_wget__fetch('npm-download-v0.10.20') }
-  it { should_not contain_exec('npm-install-v0.10.20') }
+    it { should contain_file('nodejs-symlink-bin-with-version-v0.10.20') \
+      .with_ensure('link') \
+      .with_path('/usr/local/bin/node-v0.10.20') \
+      .with_target('/usr/local/node/node-v0.10.20/bin/node')
+    }
+
+    it { should_not contain_file('/usr/local/bin/node') }
+    it { should_not contain_file('/usr/local/bin/npm') }
+
+    it { should_not contain_wget__fetch('npm-download-v0.10.20') }
+    it { should_not contain_exec('npm-install-v0.10.20') }
+  end
+
+  describe 'with specific version v0.10.19' do
+
+    let(:params) {{
+      :version => 'v0.10.19'
+    }}
+
+    it { should contain_file('nodejs-install-dir') \
+      .with_ensure('directory')
+    }
+
+    it { should contain_wget__fetch('nodejs-download-v0.10.19') \
+      .with_source('http://nodejs.org/dist/v0.10.19/node-v0.10.19.tar.gz') \
+      .with_destination('/usr/local/node/node-v0.10.19.tar.gz')
+    }
+
+    it { should contain_file('nodejs-check-tar-v0.10.19') \
+      .with_ensure('file') \
+      .with_path('/usr/local/node/node-v0.10.19.tar.gz')
+    }
+
+    it { should contain_exec('nodejs-unpack-v0.10.19') \
+      .with_command('tar -xzvf node-v0.10.19.tar.gz -C /usr/local/node/node-v0.10.19 --strip-components=1') \
+      .with_cwd('/usr/local/node') \
+      .with_unless('test -f /usr/local/node/node-v0.10.19/bin/node')
+    }
+
+    it { should contain_file('/usr/local/node/node-v0.10.19') \
+      .with_ensure('directory')
+    }
+
+    it { should contain_exec('nodejs-make-install-v0.10.19') \
+      .with_command('./configure --prefix=/usr/local/node/node-v0.10.19 && make && make install') \
+      .with_cwd('/usr/local/node/node-v0.10.19') \
+      .with_unless('test -f /usr/local/node/node-v0.10.19/bin/node')
+    }
+
+    it { should contain_file('nodejs-symlink-bin-with-version-v0.10.19') \
+      .with_ensure('link') \
+      .with_path('/usr/local/bin/node-v0.10.19') \
+      .with_target('/usr/local/node/node-v0.10.19/bin/node')
+    }
+
+    it { should_not contain_file('/usr/local/bin/node') }
+    it { should_not contain_file('/usr/local/bin/npm') }
+
+    it { should_not contain_wget__fetch('npm-download-v0.10.19') }
+    it { should_not contain_exec('npm-install-v0.10.19') }
+  end
+
+
+  describe 'with a given target_dir' do
+    let(:params) {{
+      :target_dir => '/bin'
+    }}
+
+    it { should contain_file('nodejs-symlink-bin-with-version-v0.10.20') \
+      .with_ensure('link') \
+      .with_path('/bin/node-v0.10.20') \
+      .with_target('/usr/local/node/node-v0.10.20/bin/node')
+    }
+  end
+
+  describe 'without NPM' do
+    let(:params) {{
+      :with_npm => false
+    }}
+
+    it { should_not contain_exec('npm-download-v0.10.20') }
+    it { should_not contain_exec('npm-install-v0.10.20') }
+  end
+
+  describe 'with make_install = false' do
+    let(:params) {{
+      :make_install => false
+    }}
+
+    it { should_not contain_exec('nodejs-make-install-v0.10.20') }
+  end
 end


### PR DESCRIPTION
It was not possible to install multiple different versions of nodejs
e.g.:

``` puppet
nodejs::install{"v0.10.20": version => "v0.10.20"}
nodejs::install{"v0.10.19": version => "v0.10.19"}
```
- fixed double resource definition errors
- an archive is extracted into /usr/local/node/node-$version
- nodejs::install symlink of nodejs contains the version
- class nodejs is responsible for symlink $target_dir/node
- enhanced ./configure to install nodejs into /usr/local/node/node-
  $version instead of /usr/local
- fixed puppet lint issues
- fixed node symlink issue with non semver versions
- improved default values handling
- refactored nodejs class spec
- fixed typo inside README.md
- fixed broken spec for define nodejs::install
- enhanced spec for define nodejs::install

Known limitation: just a single nodejs::install define of versions below
v0.6.3 is supportet!
