### PR TITLE
introduced is_binary_download_available check

### DIFF
--- a/lib/puppet/parser/functions/is_binary_download_available.rb
+++ b/lib/puppet/parser/functions/is_binary_download_available.rb
@@ -1,0 +1,12 @@
+require 'semver'
+
+module Puppet::Parser::Functions
+  newfunction(:is_binary_download_available, :type => :rvalue) do |args|
+
+    # since version v0.10.0 nodejs.org provides binary files
+    binaryAvailable = SemVer.new('v0.10.0')
+    currentVersion = SemVer.new(args[0]);
+
+    (currentVersion >= binaryAvailable)
+  end
+end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -68,6 +68,10 @@ define nodejs::install (
 
   $node_unpack_folder = "${::nodejs::params::install_dir}/node-${node_version}"
 
+  if (!$make_install and !is_binary_download_available($node_version)) {
+    fail("No binary download available for nodejs ${node_version}! Please run with make_install => true")
+  }
+
   if $make_install {
     $node_filename       = "node-${node_version}.tar.gz"
     $node_fqv            = $node_version # TODO remove not used

--- a/spec/functions/is_binary_download_available_spec.rb
+++ b/spec/functions/is_binary_download_available_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'is_binary_download_available' do
+  it { should run.with_params('v0.10.0').and_return(true) }
+  it { should run.with_params('v0.10.1').and_return(true) }
+  it { should run.with_params('v0.8.0').and_return(false) }
+end


### PR DESCRIPTION
since version v0.10.0 nodejs.org provides binary files for download. running make_install => false for a version below v0.10.0 will trigger a puppet fail!
