### PR TITLE
fixed npm install for nodejs versions below 0.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,6 @@ Run the following command:
 
     BUNDLE_GEMFILE=.gemfile bundle exec rake test
 
-Known Limitations
------------------
-* Just a single nodejs::install define of versions below v0.6.3 is supported!
-
 License
 -------
 

--- a/spec/defines/nodejs_install_spec.rb
+++ b/spec/defines/nodejs_install_spec.rb
@@ -102,6 +102,34 @@ describe 'nodejs::install', :type => :define do
     it { should_not contain_exec('npm-install-v0.10.19') }
   end
 
+  describe 'with specific version v0.6.2' do
+
+    let(:params) {{
+      :version  => 'v0.6.2',
+      :with_npm => true,
+    }}
+
+    it { should contain_file('/usr/local/node/node-v0.6.2') \
+      .with_ensure('directory')
+    }
+
+    it { should contain_wget__fetch('npm-download-v0.6.2') \
+      .with_source('https://npmjs.org/install.sh') \
+      .with_destination('/usr/local/node/node-v0.6.2/install-npm.sh')
+    }
+
+    it { should contain_exec('npm-install-v0.6.2') \
+      .with_command('sh install-npm.sh') \
+      .with_path(['/usr/local/node/node-v0.6.2/bin', '/bin', '/usr/bin']) \
+      .with_cwd('/usr/local/node/node-v0.6.2') \
+      .with_environment(['clean=yes', 'npm_config_prefix=/usr/local/node/node-v0.6.2'])
+    }
+
+    it { should_not contain_file('/usr/local/bin/node') }
+    it { should_not contain_file('/usr/local/bin/npm') }
+
+  end
+
 
   describe 'with a given target_dir' do
     let(:params) {{


### PR DESCRIPTION
Solves known limitation:
- Just a single nodejs::install define of versions below v0.6.3 is
  supported
