### PR TITLE
Fix #25 (install require name)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,14 +59,14 @@ class nodejs (
   file { $node_binary:
     ensure  => 'link',
     target  => $node_symlink_target,
-    require => Nodejs::Install["node-${version}"],
+    require => Nodejs::Install["nodejs-${version}"],
   }
 
   if $with_npm {
     file { $npm_binary:
       ensure  => 'link',
       target  => $npm_symlink_target,
-      require => Nodejs::Install["node-${version}"],
+      require => Nodejs::Install["nodejs-${version}"],
     }
   }
 }


### PR DESCRIPTION
Hi,
Your module is great, but latest version has small issue. Two resources file:$node_binary and file:$npm_binary in init.pp manifest has require => Nodejs::Install["node-${version}"] but resource is nodejs::install { "nodejs-${version}" ("node-${version}" vs "nodejs-${version}").

Sorry for duplicate, I'm not very familiar with github pullrequests
