### PR TITLE
expose npm installed binaries via system $PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ class { 'nodejs':
 }
 ```
 
-By default, this module creates symlinks for each Node.js version installed into
-`/usr/local/bin`. A nodejs::install define creates a versioned symlink like `/usr/local/bin/node-v0.10.17`. The class `nodejs` creates the default symlink `/usr/local/bin/node`. You can change this behavior by using the `target_dir` parameter.
+By default, this module creates a symlink for the node binary (and npm) with Node.js version appended into `/usr/local/bin` e.g. `/usr/local/bin/node-v0.10.17`.
+You can change this behavior by using the `target_dir` parameter.
+Using the nodejs class, binary files are exposed to the system $PATH without a version string appended.
 
 Also, this module installs [NPM](https://npmjs.org/) by default. You can set the
 `with_npm` parameter to `false` to not install it.

--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
 
   has_feature :versionable
 
-  commands :npm => 'npm'
+  commands :npm => '/usr/local/node/node-default/bin/npm'
 
   def self.npmlist
     begin

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,30 +43,22 @@ class nodejs (
     default   => $version
   }
 
-  $node_symlink_target = "/usr/local/node/node-${$node_version}/bin/node"
-  $npm_symlink_target = "/usr/local/node/node-${$node_version}/bin/npm"
+  $nodejs_version_path = "/usr/local/node/node-${$node_version}"
+  $nodejs_default_path = '/usr/local/node/node-default'
 
-  $node_binary = $target_dir ? {
-    undef   => '/usr/local/bin/node',
-    default => "${target_dir}/node"
-  }
-
-  $npm_binary = $target_dir ? {
-    undef   => '/usr/local/bin/npm',
-    default => "${target_dir}/npm"
-  }
-
-  file { $node_binary:
-    ensure  => 'link',
-    target  => $node_symlink_target,
+  file { $nodejs_default_path:
+    ensure  => link,
+    target  => $nodejs_version_path,
     require => Nodejs::Install["nodejs-${version}"],
   }
 
-  if $with_npm {
-    file { $npm_binary:
-      ensure  => 'link',
-      target  => $npm_symlink_target,
-      require => Nodejs::Install["nodejs-${version}"],
-    }
+  file { '/etc/profile.d/nodejs.sh':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template("${module_name}/nodejs.sh.erb"),
+    require => File[$nodejs_default_path],
   }
+
 }

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -15,15 +15,12 @@ describe 'nodejs', :type => :class do
       .with_make_install('true')
     }
 
-    it { should contain_file('/usr/local/bin/node') \
+    it { should contain_file('/usr/local/node/node-default') \
       .with_ensure('link') \
-      .with_target('/usr/local/node/node-v0.10.20/bin/node')
+      .with_target('/usr/local/node/node-v0.10.20')
     }
 
-    it { should contain_file('/usr/local/bin/npm') \
-      .with_ensure('link') \
-      .with_target('/usr/local/node/node-v0.10.20/bin/npm')
-    }
+    it { should contain_file('/etc/profile.d/nodejs.sh') }
   end
 
   describe 'with a given version' do
@@ -35,9 +32,9 @@ describe 'nodejs', :type => :class do
       .with_version('v0.10.0')
     }
 
-    it { should contain_file('/usr/local/bin/node') \
+    it { should contain_file('/usr/local/node/node-default') \
       .with_ensure('link') \
-      .with_target('/usr/local/node/node-v0.10.0/bin/node')
+      .with_target('/usr/local/node/node-v0.10.0')
     }
   end
 
@@ -49,11 +46,6 @@ describe 'nodejs', :type => :class do
     it { should contain_nodejs__install('nodejs-stable') \
       .with_target_dir('/bin') \
     }
-  
-    it { should contain_file('/bin/node') \
-      .with_ensure('link') \
-      .with_target('/usr/local/node/node-v0.10.20/bin/node')
-    }
   end
 
   describe 'without NPM' do
@@ -64,8 +56,6 @@ describe 'nodejs', :type => :class do
     it { should contain_nodejs__install('nodejs-stable') \
       .with_with_npm('false')
     }
-
-    it { should_not contain_file('/usr/local/bin/npm') }
   end
 
   describe 'with make_install = false' do
@@ -78,3 +68,4 @@ describe 'nodejs', :type => :class do
     }
   end
 end
+

--- a/templates/nodejs.sh.erb
+++ b/templates/nodejs.sh.erb
@@ -1,0 +1,9 @@
+#
+# THIS FILE IS MANAGED VIA PUPPET - DON'T CHANGE ANY CONTENT HERE!
+#
+NODEJS_HOME=<%= @nodejs_default_path %>
+
+if [ -d "$NODEJS_HOME/bin" ] ; then
+  export PATH="$NODEJS_HOME/bin:$PATH"
+fi
+


### PR DESCRIPTION
Via /etc/profile.d/nodejs.sh all Node.js binaries of the puppet class are exposed to the system $PATH
