### PR TITLE
add .gittatributes to prevent errors on Vagrant/Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh.erb	eol=lf


### PR DESCRIPTION
When cloning the repo on Windwos and using Vagrant, `/etc/profiles.d/nodejs.sh` will have Windows line endings, which causes the following error:

``` sh
/etc/profile.d/nodejs.sh: line 5: $'\r': command not found
/etc/profile.d/nodejs.sh: line 10: syntax error: unexpected end of file
```

Fix by making sure `git` will checkout `*.sh.erb` files with unix line endings.
