### PR TITLE
Make npm executable

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -193,5 +193,13 @@ define nodejs::install (
         Package['curl'],
       ],
     }
+    
+    file{'npm-make-exec':
+      path    => '/usr/local/node/node-default/bin/npm',
+      ensure  => present,
+      mode    => '+x',
+      require => Exec["npm-install-${node_version}"]
+    }
+    
   }
 }


### PR DESCRIPTION
Client manifests can't use npm to install node.js dependencies unless the npm script is executable.

Ex. Will raise `Can't find program /usr/local/node/node-default/bin/npm`

``` ruby
exec { 'npm-install':
    command => '/usr/local/node/node-default/bin/npm install -d',
    cwd         => $application_directory,
  }
```
