### PR TITLE
added npm.pp from puppetlabs-nodejs and make_default option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,13 +27,15 @@ class nodejs (
   $target_dir   = '/usr/local/bin',
   $with_npm     = true,
   $make_install = true,
+  $make_default = false,
 ) {
 
   nodejs::install { "nodejs-${version}":
-    version       => $version,
-    target_dir    => $target_dir,
-    with_npm      => $with_npm,
-    make_install  => $make_install,
+    version      => $version,
+    target_dir   => $target_dir,
+    with_npm     => $with_npm,
+    make_install => $make_install,
+    make_default => $make_default,
   }
 
   $node_version = $version ? {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,6 +29,7 @@ define nodejs::install (
   $target_dir   = undef,
   $with_npm     = true,
   $make_install = true,
+  $make_default = false,
 ) {
 
   include nodejs::params
@@ -165,9 +166,17 @@ define nodejs::install (
   }
 
   file { "nodejs-symlink-bin-with-version-${node_version}":
-    ensure  => 'link',
-    path    => $node_symlink,
-    target  => $node_symlink_target,
+    ensure => 'link',
+    path   => $node_symlink,
+    target => $node_symlink_target,
+  }
+  if $make_default {
+    file { 'nodejs-default-symlink':
+      ensure  => 'link',
+      target  => $node_symlink,
+      path    => '/usr/local/bin/node',
+      require => File["nodejs-symlink-bin-with-version-${node_version}"],
+    }
   }
 
   # automatic installation of npm is introduced since nodejs v0.6.3

--- a/manifests/npm.pp
+++ b/manifests/npm.pp
@@ -1,0 +1,81 @@
+# Define: nodejs::npm
+#
+# Parameters:
+#
+# Actions:
+#
+# Requires:
+#
+# Usage:
+#
+define nodejs::npm (
+  $ensure       = present,
+  $version      = undef,
+  $source       = undef,
+  $install_opt  = undef,
+  $remove_opt   = undef,
+  $exec_as_user = undef
+) {
+  include nodejs
+
+  $npm = split($name, ':')
+  $npm_dir = $npm[0]
+  $npm_pkg = $npm[1]
+
+  if $source {
+    $install_pkg = $source
+  } elsif $version {
+    $install_pkg = "${npm_pkg}@${version}"
+  } else {
+    $install_pkg = $npm_pkg
+  }
+
+  if $version {
+    $validate = "${npm_dir}/node_modules/${npm_pkg}:${npm_pkg}@${version}"
+  } else {
+    $validate = "${npm_dir}/node_modules/${npm_pkg}"
+  }
+
+  # exec_as_user allows to install an npm package only for a certain user
+  # exec environment depends on exec user
+  if $exec_as_user == undef {
+    # if exec user is undefined, exec environment should not be set, so the package will get installed globally
+    $exec_env = undef
+  } else {
+    # if exec user is defined, exec environment depends on the operating system
+    case $::operatingsystem {
+      'Debian','Ubuntu','RedHat','SLEL','Fedora','CentOS': {
+        $exec_env = "HOME=/home/${exec_as_user}"
+      }
+      default: {
+        # so far only linux systems are supported with this option
+        fail('unsupported operating system')
+      }
+    }
+  }
+
+  if $ensure == present {
+    exec { "npm_install_${name}":
+      command     => "npm install ${install_opt} ${install_pkg}",
+      unless      => "npm list -p -l | grep '${validate}'",
+      cwd         => $npm_dir,
+      path        => $::path,
+      require     => Class['nodejs'],
+      user        => $exec_as_user,
+      environment => $exec_env,
+    }
+
+    # Conditionally require npm_proxy only if resource exists.
+    Exec<| title=='npm_proxy' |> -> Exec["npm_install_${name}"]
+  } else {
+    exec { "npm_remove_${name}":
+      command     => "npm remove ${npm_pkg}",
+      onlyif      => "npm list -p -l | grep '${validate}'",
+      cwd         => $npm_dir,
+      path        => $::path,
+      require     => Class['nodejs'],
+      user        => $exec_as_user,
+      environment => $exec_env,
+    }
+  }
+}


### PR DESCRIPTION
Hi, I just switched from puppetlabs-nodejs to willdurand/puppet-nodejs to get the latest node version installed with my puppet-sinopia module and to get out of package manager hell for nodejs+npm installations on debian systems for now. Unfortunately, saheba/puppet-sinopia relies on the npm.pp from puppetlabs. I merged npm.pp from puppetlabs-nodejs into your puppet nodejs module, so I can enjoy the best of both ;-) I also added a make_default option to be able to select one nodejs installation as the primary one by adding a symlink /usr/local/bin/node pointing to the version which is installed with make_default to true. This change is backwards compatible, because the option's default value is false.

The rake test run results for this branch:
---> syntax:manifests
---> syntax:templates
---> syntax:hiera:yaml
Cloning into 'spec/fixtures/modules/stdlib'...
remote: Counting objects: 5561, done.
remote: Total 5561 (delta 0), reused 0 (delta 0)
Receiving objects: 100% (5561/5561), 1.10 MiB | 423 KiB/s, done.
Resolving deltas: 100% (2307/2307), done.
Cloning into 'spec/fixtures/modules/wget'...
remote: Counting objects: 534, done.
remote: Compressing objects: 100% (262/262), done.
remote: Total 534 (delta 223), reused 534 (delta 223)
Receiving objects: 100% (534/534), 82.21 KiB, done.
Resolving deltas: 100% (223/223), done.
/.rvm/rubies/ruby-2.1.2/bin/ruby -S rspec spec/classes/nodejs_spec.rb spec/defines/nodejs_install_spec.rb spec/functions/is_binary_download_available_spec.rb spec/functions/is_npm_provided_spec.rb --color
WARN: Unresolved specs during Gem::Specification.reset:
      rake (>= 0)
      rspec (>= 0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
...............................................

Finished in 3.57 seconds
47 examples, 0 failures

Let me know if there is anything else to do to get this merged.
