### PR TITLE
Fix npm list --json parsing error

### DIFF
--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -20,7 +20,8 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
     begin
       output = execute([command(:npm), 'list', '--json', '--global'], {:combine => false})
       # ignore any npm output lines to be a bit more robust
-      output = PSON.parse(output.lines.select{ |l| l =~ /^((?!^npm).*)$/}.join("\n"))
+      # set max_nesting to 100 so parsing will not fail if we have module with big dependencies tree
+      output = PSON.parse(output.lines.select{ |l| l =~ /^((?!^npm).*)$/}.join("\n"), {:max_nesting => 100})
       @npmlist = output['dependencies'] || {}
     rescue Exception => e
       Puppet.debug("Error: npm list --json command error #{e.message}")


### PR DESCRIPTION
Modern Node.js module can have more than 20 nested dependencies (like strongloop, for example). And PSON.parse after more than 20 nested objects raises appropriate exception. Setting max_nesting to 100 helps to avoid such behavior
