### PR TITLE
Introduced metadata.json, removed Modulefile

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,9 +1,0 @@
-name        'willdurand-nodejs'
-version '1.7.2'
-summary     'This module allows to install Node.js and NPM.'
-description 'This module allows to install Node.js and NPM.'
-license     'MIT'
-author      'William Durand'
-
-dependency  'puppetlabs/stdlib', '>=3.2.1'
-dependency  'maestrodev/wget',   '>=1.2.0'

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,60 @@
+{
+  "name": "willdurand-nodejs",
+  "version": "1.7.2",
+  "author": "William Durand",
+  "license": "MIT",
+  "summary": "A module to install Node.js and NPM.",
+  "source": "https://github.com/willdurand/puppet-nodejs",
+  "project_page": "https://github.com/willdurand/puppet-nodejs",
+  "issues_url": "https://github.com/willdurand/puppet-nodejs/issues",
+  "tags": [
+    "node",
+    "nodejs",
+    "npm"
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "12.04",
+        "14.04"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">=2.7"
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">=3.2.1"
+    },
+    {
+      "name": "maestrodev/wget",
+      "version_requirement": ">=1.2.0"
+    }
+  ]
+}


### PR DESCRIPTION
See
https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html

"DEPRECATION WARNING As of Puppet 3.6 the Modulefile has been deprecated
in favor of the metadata.json file."

Maybe we should talk about the operatingsystem_support and requirements section ... it's just a guess! Feedback is welcome @willdurand 
