### PR TITLE
Check if $gplusplus_package is defined

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -154,7 +154,11 @@ define nodejs::install (
       }
     }
 
-    ensure_packages([ 'python', $gplusplus_package, 'make' ])
+    ensure_packages([ 'python', 'make' ])
+    
+    if !defined(Package[$gplusplus_package]) {
+      ensure_packages([ $gplusplus_package ])
+    }
 
     exec { "nodejs-make-install-${node_version}":
       command => "./configure --prefix=${node_unpack_folder} && make && make install",


### PR DESCRIPTION
Ran into gcc++ duplication errors so I added a check to see if $gplusplus_package is already installed.