### PR TITLE
Fix for issue `Duplicate declaration: File[nodejs-default-symlink]`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,6 @@ class nodejs (
   $target_dir   = '/usr/local/bin',
   $with_npm     = true,
   $make_install = true,
-  $create_symlinks = false,
 ) {
 
   nodejs::install { "nodejs-${version}":
@@ -35,7 +34,6 @@ class nodejs (
     target_dir   => $target_dir,
     with_npm     => $with_npm,
     make_install => $make_install,
-    create_symlinks => $create_symlinks,
   }
 
   $node_version = $version ? {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,6 @@ define nodejs::install (
   $target_dir   = undef,
   $with_npm     = true,
   $make_install = true,
-  $create_symlinks = true,
 ) {
 
   include nodejs::params
@@ -177,15 +176,6 @@ define nodejs::install (
     ensure => 'link',
     path   => $node_symlink,
     target => $node_symlink_target,
-  }
-
-  if $create_symlinks {
-    file { 'nodejs-default-symlink':
-      ensure  => 'link',
-      target  => $node_symlink,
-      path    => '/usr/local/bin/node',
-      require => File["nodejs-symlink-bin-with-version-${node_version}"],
-    }
   }
 
   # automatic installation of npm is introduced since nodejs v0.6.3


### PR DESCRIPTION
Installing a few versions of node like attached example triggers puppet
run to fail with `Duplicate declaration: File[nodejs-default-symlink]`

The cause of this problem is a `define` vs `class` issue. When a symlink
like `/usr/local/bin/node` is desirable, the `class {'nodejs':}` has to
handle this symlink.

Manifest:

``` puppet
nodejs::install { 'v0.10.17':
version => 'v0.10.17',
}
nodejs::install { 'v0.10.25':
version => 'v0.10.25',
}
```

Error:

``` bash
...
==> precise64: Running provisioner: puppet...
==> precise64: Running Puppet with site.pp...
==> precise64: stdin: is not a tty
==> precise64: Duplicate declaration: File[nodejs-default-symlink] is
already declared in file /tmp/vagrant-
puppet-3/modules-0/nodejs/manifests/install.pp at line 188; cannot
redeclare at /tmp/vagrant-
puppet-3/modules-0/nodejs/manifests/install.pp:188 on node
precise64.example.com
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

puppet apply --modulepath '/tmp/vagrant-
puppet-3/modules-0:/etc/puppet/modules' --manifestdir /tmp/vagrant-
puppet-3/manifests --detailed-exitcodes /tmp/vagrant-
puppet-3/manifests/site.pp

Stdout from the command:

Stderr from the command:

stdin: is not a tty
Duplicate declaration: File[nodejs-default-symlink] is already declared
in file /tmp/vagrant-puppet-3/modules-0/nodejs/manifests/install.pp at
line 188; cannot redeclare at /tmp/vagrant-
puppet-3/modules-0/nodejs/manifests/install.pp:188 on node
precise64.example.com
```
