### PR TITLE
The node and npm symlinks are not created in $target_dir as per the module documentation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,23 @@ class nodejs (
     target  => $nodejs_version_path,
     require => Nodejs::Install["nodejs-${version}"],
   }
+  
+  $node_default_symlink = "${target_dir}/node"
+  $node_default_symlink_target = "${nodejs_default_path}/bin/node"
+  $npm_default_symlink = "${target_dir}/npm"
+  $npm_default_symlink_target = "${nodejs_default_path}/bin/npm"
+  
+  file { $node_default_symlink:
+    ensure	=> link,
+	target	=> $node_default_symlink_target,
+	require	=> File[$nodejs_default_path]
+  }
+  
+  file { $npm_default_symlink:
+    ensure	=> link,
+	target	=> $npm_default_symlink_target,
+	require	=> File[$nodejs_default_path]
+  }
 
   file { '/etc/profile.d/nodejs.sh':
     ensure  => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,15 +58,15 @@ class nodejs (
   $npm_default_symlink_target = "${nodejs_default_path}/bin/npm"
   
   file { $node_default_symlink:
-    ensure	=> link,
-	target	=> $node_default_symlink_target,
-	require	=> File[$nodejs_default_path]
+    ensure  => link,
+    target  => $node_default_symlink_target,
+    require => File[$nodejs_default_path]
   }
   
   file { $npm_default_symlink:
-    ensure	=> link,
-	target	=> $npm_default_symlink_target,
-	require	=> File[$nodejs_default_path]
+    ensure  => link,
+    target  => $npm_default_symlink_target,
+    require => File[$nodejs_default_path]
   }
 
   file { '/etc/profile.d/nodejs.sh':


### PR DESCRIPTION
The module documentation states that symlinks for `node` and `npm` would be created in `$target_dir` as part of the node.js installation but this is not the case. The only symlink that is created in `/usr/local/bin` (the default value for `$target_dir`) is a `node-${node_version}` symlink which points to `${node_unpack_folder}/bin/node`. `node` and `npm` symlinks are not created. My fix for this issue creates the following 2 symlinks in `$target_dir`:

* `node -> /usr/local/node/node-default/bin/node`
* `npm -> /usr/local/node/node-default/bin/npm`

The code is added to `init.pp` due to the fact that currently that's the code which creates the node-default symlink.