### PR TITLE
Fix for #81

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ package { 'express':
 }
 ```
 
+### Proxy
+
+When your puppet agent is behind a web proxy, export the `http_proxy` environment variable:
+
+```bash
+export http_proxy=http://myHttpProxy:8888
+```
 
 Running the tests
 -----------------


### PR DESCRIPTION
Enable ruby based facts to work behind an http proxy.

Export http_proxy env variable with your proxy settings e.g.:

`export http_proxy=http://myCompanyProxy:8888`

Think this should work for wget / curl, too.