### PR TITLE
Unable to install second module with similar name (e.g. 'sinopia-ldap' and 'sinopia')

### DIFF
--- a/manifests/npm.pp
+++ b/manifests/npm.pp
@@ -57,7 +57,7 @@ define nodejs::npm (
   if $ensure == present {
     exec { "npm_install_${name}":
       command     => "npm install ${install_opt} ${install_pkg}",
-      unless      => "npm list -p -l | grep '${validate}'",
+      unless      => "npm list -p -l | grep '${validate}$'",
       cwd         => $npm_dir,
       path        => $::path,
       require     => Class['nodejs'],
@@ -70,7 +70,7 @@ define nodejs::npm (
   } else {
     exec { "npm_remove_${name}":
       command     => "npm remove ${npm_pkg}",
-      onlyif      => "npm list -p -l | grep '${validate}'",
+      onlyif      => "npm list -p -l | grep '${validate}$'",
       cwd         => $npm_dir,
       path        => $::path,
       require     => Class['nodejs'],


### PR DESCRIPTION
We experienced a problem with the ::nodejs::npm define:

1. We succesfully installed a node.js module 'sinopia-ldap' in path '/var/www/sinopia/node_modules'.
2. After that we wanted to install 'sinopia', also in that path.

Both with ::nodejs::npm. The strange thing was that we had no clue why the second one was never executed. Then we analyzed under which circumstances the installation of a module is executed and found the 'unless' which checks with the npm list command (together with grep) whether the module does not exists already.

Problem now is that the grep for 2nd module 'sinopia' matches too much, in this case it matched also the 'sinopia-ldap' stuff, we could check this with CLI as well (simulating the list command):

```
vagrant@sinopia:/var/www/sinopia$ npm list -p -l | grep '/var/www/sinopia/node_modules/sinopia'
/var/www/sinopia/node_modules/sinopia-ldap:sinopia-ldap@0.5.1:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapauth-fork:ldapauth-fork@2.3.3:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapauth-fork/node_modules/bcryptjs:bcryptjs@2.1.0:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapauth-fork/node_modules/lru-cache:lru-cache@2.5.0:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs:ldapjs@0.7.1:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/asn1:asn1@0.2.1:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/assert-plus:assert-plus@0.1.5:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/bunyan:bunyan@0.22.1:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/bunyan/node_modules/mv:mv@0.0.5:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/nopt:nopt@2.1.1:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/nopt/node_modules/abbrev:abbrev@1.0.7:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/pooling:pooling@0.4.6:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/pooling/node_modules/once:once@1.3.0:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/pooling/node_modules/vasync:vasync@1.4.0:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/pooling/node_modules/vasync/node_modules/jsprim:jsprim@0.3.0:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/pooling/node_modules/vasync/node_modules/jsprim/node_modules/extsprintf:extsprintf@1.0.0:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/pooling/node_modules/vasync/node_modules/jsprim/node_modules/json-schema:json-schema@0.2.2:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/pooling/node_modules/vasync/node_modules/jsprim/node_modules/verror:verror@1.3.3:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/pooling/node_modules/vasync/node_modules/verror:verror@1.1.0:
/var/www/sinopia/node_modules/sinopia-ldap/node_modules/ldapjs/node_modules/pooling/node_modules/vasync/node_modules/verror/node_modules/extsprintf:extsprintf@1.0.0:
vagrant@sinopia:
```
Result was that it was not installed!

Could be fixed with a simple $ sign at the end of the grep value like grep '..$' (pls refer also to  http://www.robelle.com/smugbook/regexpr.html):

```
vagrant@sinopia:/var/www/sinopia$ npm list -p -l | grep '/var/www/sinopia/node_modules/sinopia$'
vagrant@sinopia:/var/www/sinopia$  
```

Best regards
