### PR TITLE
When http_proxy is not set with http/https facter is not successful 

### DIFF
--- a/lib/facter/nodejs_functions.rb
+++ b/lib/facter/nodejs_functions.rb
@@ -54,7 +54,11 @@ def get_version_list
 
   http_proxy = ENV["http_proxy"]
   if http_proxy.to_s != ''
-    proxy = URI.parse(http_proxy)
+    if http_proxy =~ /^http[s]{0,1}:\/\/.*/
+      proxy = URI.parse(http_proxy)
+    else
+      proxy = URI.parse('http://' + http_proxy)
+    end
     request = Net::HTTP::Proxy(proxy.host, proxy.port).new(uri.host, uri.port)
   else
     request = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
In some cases env variable http_proxy needs to be set without protocol (http/https) prefix. I've added check to facter - if http/https is missing in http_proxy, it will be added during facter execution.