### PR TITLE
create version-aware executables to provide multiple npm installations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,5 @@ before_install:
 script: "rake test"
 
 gemfile: .gemfile
+
+sudo: false

--- a/lib/puppet/parser/functions/npm_version.rb
+++ b/lib/puppet/parser/functions/npm_version.rb
@@ -1,6 +1,6 @@
 module Puppet::Parser::Functions
   newfunction(:npm_version, :type => :rvalue) do |args|
-    node_unpack_folder = args[0]
+    node_unpack_folder = args.shift
     version            = `#{node_unpack_folder}/bin/npm -v`
 
     # the version will be extracted from the CLI.

--- a/lib/puppet/parser/functions/npm_version.rb
+++ b/lib/puppet/parser/functions/npm_version.rb
@@ -1,0 +1,11 @@
+module Puppet::Parser::Functions
+  newfunction(:npm_version, :type => :rvalue) do |args|
+    node_unpack_folder = args[0]
+    version            = `#{node_unpack_folder}/bin/npm -v`
+
+    # the version will be extracted from the CLI.
+    # the output contains a line break, but this line break causes weird
+    # symlink names, so the version needs to be stripped.
+    version.strip
+  end
+end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -100,9 +100,9 @@ define nodejs::install (
   $node_symlink_target = "${node_unpack_folder}/bin/node"
   $node_symlink = "${node_target_dir}/node-${node_version}"
 
-  $npm_version     = npm_version($node_unpack_folder)
-  $npm_target_dir  = "${node_unpack_folder}/bin"
-  $npm_filename    = "${node_target_dir}/npm-${npm_version}"
+  $npm_version    = npm_version($node_unpack_folder)
+  $npm_target_dir = "${node_unpack_folder}/bin"
+  $npm_filename   = "${node_target_dir}/npm-${npm_version}"
 
   ensure_resource('file', 'nodejs-install-dir', {
     ensure => 'directory',
@@ -216,7 +216,7 @@ define nodejs::install (
 
     file { $npm_filename:
       ensure  => file,
-      mode    => 0777,
+      mode    => '0777',
       content => template($npm_template_name)
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -100,6 +100,10 @@ define nodejs::install (
   $node_symlink_target = "${node_unpack_folder}/bin/node"
   $node_symlink = "${node_target_dir}/node-${node_version}"
 
+  $npm_version     = npm_version($node_unpack_folder)
+  $npm_target_dir  = "${node_unpack_folder}/bin"
+  $npm_filename    = "${node_target_dir}/npm-${npm_version}"
+
   ensure_resource('file', 'nodejs-install-dir', {
     ensure => 'directory',
     path   => $::nodejs::params::install_dir,
@@ -205,6 +209,15 @@ define nodejs::install (
         Wget::Fetch["npm-download-${node_version}"],
         Package['curl'],
       ],
+    }
+  }
+  else {
+    $npm_template_name = "${module_name}/npm.erb"
+
+    file { $npm_filename:
+      ensure  => file,
+      mode    => 0777,
+      content => template($npm_template_name)
     }
   }
 }

--- a/templates/npm.erb
+++ b/templates/npm.erb
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+<%= @node_symlink %> <%= @node_unpack_folder %>/bin/npm $@


### PR DESCRIPTION
this is not related to #83 .

resolves #94 

The issue is that when having multiple node instances in a VM, there are multiple executables (node-v5.4.1, node-v0.12.2, etc.), but not multiple npm executables.
This is because of the fact that npm's executable always calls the "node" executable, but this means that even npm 2 would work with node 5 and not with node 0.12 although npm 2 has been installed with npm 0.12.
The fix for that issue was to create executables like "npm-2.7.4", etc., but those call inside the proper "npm" callable, but with the proper npm executable, so it is possible execute the proper executable with the proper node environment.