### PR TITLE
package.json installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,39 @@ package { 'express':
 }
 ```
 
+### NPM installer
+
+The nodejs installer can be used if a npm package should not be installed globally, but in a certain directory.
+
+There are two approaches how to use this feature:
+
+#### Installing a single package into a directory
+
+```puppet
+::nodejs::npm { 'npm-webpack':
+  ensure       => present, # absent would uninstall this package
+  pkg_name     => 'webpack',
+  version      => 'x.x', # optional
+  install_opt  => '-x -y -z', # options passed to the "npm install" cmd, optional
+  remove_opt   => '-x -y -z', # options passed to the "npm remove" cmd (in case of ensure => absent), optional
+  exec_as_user => 'vagrant',  # exec user, optional
+  directory    => '/target/directory', # target directory
+}
+```
+
+This would install the package ``webpack`` into ``/target/directory`` with version ``x.x``.
+
+#### Executing a ``package.json`` file
+
+```puppet
+::nodejs::npm { 'npm-install-dir':
+  list         => true, # flag to tell puppet to execute the package.json file
+  directory    => '/target',
+  exec_as_user => 'vagrant',
+  install_opt  => '-x -y -z',
+}
+```
+
 ### Proxy
 
 When your puppet agent is behind a web proxy, export the `http_proxy` environment variable:

--- a/manifests/npm/file.pp
+++ b/manifests/npm/file.pp
@@ -1,0 +1,38 @@
+# = Define: nodejs::npm::file
+#
+# Define that installs dependencies from a package file into a certain directory.
+# NOTE: this is just a private definition and not meant for public usage.
+#
+# == Parameters:
+#
+# [*directory*]
+#   Target directory.
+#
+# [*options*]
+#   Options to adjust for the npm commands (optional).
+#
+# [*exec_user*]
+#   User which should execute the command (optional).
+#
+# [*exec_env*]
+#   Exec environment.
+#
+define nodejs::npm::file(
+  $directory,
+  $exec_user = undef,
+  $exec_env  = undef,
+  $options   = undef,
+) {
+  if $caller_module_name != $module_name {
+    warning('::nodejs::npm::file is not meant for public use!')
+  }
+
+  exec { "npm_install_dir_${directory}":
+    command     => "npm install ${options}",
+    cwd         => $directory,
+    path        => $::path,
+    require     => Class['nodejs'],
+    user        => $exec_user,
+    environment => $exec_env,
+  }
+}

--- a/manifests/npm/package.pp
+++ b/manifests/npm/package.pp
@@ -44,8 +44,8 @@ define nodejs::npm::package(
   }
 
   $install_pkg = $version ? {
-    undef   => "${npm_pkg}@${version}",
-    default => $npm_pkg
+    undef   => $npm_pkg,
+    default => "${npm_pkg}@${version}"
   }
 
   $validate = "${npm_dir}/node_modules/${npm_pkg}:${install_pkg}"

--- a/manifests/npm/package.pp
+++ b/manifests/npm/package.pp
@@ -1,0 +1,78 @@
+# = Define: nodejs::npm::package
+#
+# Define that install a single package into a directory.
+# NOTE: this is just a private definition and not meant for public usage.
+#
+# == Parameters:
+#
+# [*ensure*]
+#   Whether to install or uninstall a npm module.
+#
+# [*version*]
+#   The specific version of the package to install (optional).
+#
+# [*install_opt*]
+#   Options to adjust for the npm commands (optional).
+#
+# [*remove_opt*]
+#   Options to adjust for npm removal commands (optional).
+#
+# [*exec_user*]
+#   User which should execute the command (optional).
+#
+# [*exec_env*]
+#   Exec environment.
+#
+# [*npm_dir*]
+#   Target directory.
+#
+# [*npm_pkg*]
+#   Package name.
+#
+define nodejs::npm::package(
+  $npm_dir,
+  $npm_pkg,
+  $ensure      = present,
+  $version     = undef,
+  $install_opt = undef,
+  $remove_opt  = undef,
+  $exec_user   = undef,
+  $exec_env    = undef,
+) {
+  if $caller_module_name != $module_name {
+    warning('::nodejs::npm::package is not meant for public use!')
+  }
+
+  $install_pkg = $version ? {
+    undef   => "${npm_pkg}@${version}",
+    default => $npm_pkg
+  }
+
+  $validate = "${npm_dir}/node_modules/${npm_pkg}:${install_pkg}"
+
+  if $ensure == present {
+    exec { "npm_install_${npm_pkg}_${npm_dir}":
+      command     => "npm install ${install_opt} ${install_pkg}",
+      unless      => "npm list -p -l | grep '${validate}'",
+      cwd         => $npm_dir,
+      path        => $::path,
+      require     => Class['nodejs'],
+      user        => $exec_user,
+      environment => $exec_env,
+    }
+
+    # Conditionally require npm_proxy only if resource exists.
+    Exec<| title=='npm_proxy' |> -> Exec["npm_install_${npm_pkg}_${npm_dir}"]
+  }
+  else {
+    exec { "npm_remove_${npm_pkg}_${npm_dir}":
+      command     => "npm remove ${npm_pkg}",
+      onlyif      => "npm list -p -l | grep '${validate}'",
+      cwd         => $npm_dir,
+      path        => $::path,
+      require     => Class['nodejs'],
+      user        => $exec_user,
+      environment => $exec_env,
+    }
+  }
+}

--- a/spec/defines/nodejs_npm_spec.rb
+++ b/spec/defines/nodejs_npm_spec.rb
@@ -8,9 +8,12 @@ describe 'nodejs::npm', :type => :define do
 
   describe 'install npm package' do
     let (:params) {{
-      :name => '/foo:yo',    }}
+      :name      => 'yo-foo',
+      :pkg_name  => 'yo',
+      :directory => '/foo'
+    }}
 
-    it { should contain_exec('npm_install_/foo:yo') \
+    it { should contain_exec('npm_install_yo_/foo') \
       .with_command('npm install  yo') \
       .with_unless("npm list -p -l | grep '/foo/node_modules/yo:yo'")
     }
@@ -18,11 +21,13 @@ describe 'nodejs::npm', :type => :define do
 
   describe 'uninstall npm package' do
     let (:params) {{
-      :name   => '/foo:yo',
-      :ensure => 'absent'
+      :name      => 'foo-yo',
+      :ensure    => 'absent',
+      :pkg_name  => 'yo',
+      :directory => '/foo'
     }}
 
-    it { should contain_exec('npm_remove_/foo:yo') \
+    it { should contain_exec('npm_remove_yo_/foo') \
       .with_command('npm remove yo') \
       .with_onlyif("npm list -p -l | grep '/foo/node_modules/yo:yo'")
     }
@@ -30,27 +35,15 @@ describe 'nodejs::npm', :type => :define do
 
   describe 'install npm package with version' do
     let (:params) {{
-      :name    => '/foo:yo',
-      :version => '1.4'
+      :name      => 'foo-yo',
+      :version   => '1.4',
+      :pkg_name  => 'yo',
+      :directory => '/foo'
     }}
 
-    it { should contain_exec('npm_install_/foo:yo') \
+    it { should contain_exec('npm_install_yo_/foo') \
       .with_command('npm install  yo@1.4') \
       .with_unless("npm list -p -l | grep '/foo/node_modules/yo:yo@1.4'")
-    }
-  end
-
-  describe 'install package globally from source' do
-    let (:params) {{
-      :name        => '/foo:source',
-      :version     => '1.4',
-      :source      => 'source',
-      :install_opt => '-g'
-    }}
-
-    it { should contain_exec('npm_install_/foo:source') \
-      .with_command('npm install -g source') \
-      .with_unless("npm list -p -l | grep '/foo/node_modules/source:source@1.4'")
     }
   end
 
@@ -58,19 +51,33 @@ describe 'nodejs::npm', :type => :define do
     operating_systems = ['Debian', 'Ubuntu', 'RedHat', 'SLES', 'Fedora', 'CentOS']
     operating_systems.each do |os|
       let (:params) {{
-        :name         => '/foo:yo',
-        :exec_as_user => 'Ma27'
+        :name         => 'foo-yo',
+        :exec_as_user => 'Ma27',
+        :pkg_name  => 'yo',
+        :directory => '/foo'
       }}
       let(:facts) {{
         :operatingsystem       => os,
         :nodejs_stable_version => 'v0.10.20'
       }}
 
-      it { should contain_exec('npm_install_/foo:yo') \
+      it { should contain_exec('npm_install_yo_/foo') \
         .with_command('npm install  yo') \
         .with_unless("npm list -p -l | grep '/foo/node_modules/yo:yo'") \
         .with_environment('HOME=/home/Ma27')
       }
     end
+  end
+
+  describe 'installation from a package.json file' do
+    let (:params) {{
+      :list        => true,
+      :directory   => '/foo',
+      :install_opt => '-x -z'
+    }}
+
+    it { should contain_exec('npm_install_dir_/foo') \
+      .with_command('npm install -x -z')
+    }
   end
 end


### PR DESCRIPTION
resolves #122 

refactored the ``::nodejs::npm`` define for extended use. It is possible now to install local packages from a package.json file. Furthermore the use of ``::nodejs::npm { 'dir:pkg': }`` is deprecated in favor of params.