### PR TITLE
Dynamic python package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,9 @@
 # [*node_path*]
 #   Value of the system environment variable (default: "/usr/local/node/node-default/lib/node_modules").
 #
+# [*python_package*]
+#   Python package name, defaults to python
+#
 # == Example:
 #
 #  include nodejs
@@ -26,19 +29,21 @@
 #  }
 #
 class nodejs (
-  $version      = 'stable',
-  $target_dir   = '/usr/local/bin',
-  $with_npm     = true,
-  $make_install = true,
-  $node_path    = '/usr/local/node/node-default/lib/node_modules'
+  $version        = 'stable',
+  $target_dir     = '/usr/local/bin',
+  $with_npm       = true,
+  $make_install   = true,
+  $node_path      = '/usr/local/node/node-default/lib/node_modules',
+  $python_package = 'python',
 ) {
   validate_string($node_path)
 
   nodejs::install { "nodejs-${version}":
-    version      => $version,
-    target_dir   => $target_dir,
-    with_npm     => $with_npm,
-    make_install => $make_install,
+    version        => $version,
+    target_dir     => $target_dir,
+    with_npm       => $with_npm,
+    make_install   => $make_install,
+    python_package => $python_package,
   }
 
   $node_version = $version ? {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,6 +17,9 @@
 # [*make_install*]
 #   If false, will install from nodejs.org binary distributions.
 #
+# [*python_package*]
+#   Python package name, defaults to python
+#
 # == Example:
 #
 #  class { 'nodejs':
@@ -28,11 +31,12 @@
 #  }
 #
 define nodejs::install (
-  $ensure       = present,
-  $version      = undef,
-  $target_dir   = undef,
-  $with_npm     = true,
-  $make_install = true,
+  $ensure         = present,
+  $version        = undef,
+  $target_dir     = undef,
+  $with_npm       = true,
+  $make_install   = true,
+  $python_package = 'python',
 ) {
 
   include nodejs::params
@@ -170,7 +174,7 @@ define nodejs::install (
         }
       }
 
-      ensure_packages([ 'python', $gplusplus_package, 'make' ])
+      ensure_packages([ $python_package, $gplusplus_package, 'make' ])
 
       exec { "nodejs-make-install-${node_version}":
         command => "./configure --prefix=${node_unpack_folder} && make && make install",
@@ -181,7 +185,7 @@ define nodejs::install (
         timeout => 0,
         require => [
           Exec["nodejs-unpack-${node_version}"],
-          Package['python'],
+          Package[$python_package],
           Package[$gplusplus_package],
           Package['make']
         ],


### PR DESCRIPTION
### Overview

This change allows the user to define the python package that should be used for the make of nodejs.
The change include one variable that defaults the to original hard coded value of 'python'

### Related issues

Using amz linux image on ec2 the python packages do not follow the original hard coded package name  'python' but rather 'pythonXX' where XX is the version number. In order to use this package I needed the ability to define which version of python I have installed on my machine