### PR TITLE
Add option to define parallel jobs for make and make install

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ __Note:__ It is not possible to install and uninstall an instance in the same ru
 When attempting to remove the default instance this can be only done when having the ``::nodejs`` class __NOT__ defined as otherwise ``duplicate resource`` errors would occur. 
 After that no new default instance will be configured.
 
+### Setup using custom amount of cpu cores
+
+By default, all available cpu cores are being used to compile nodejs. Set `cpu_cores` to any number of cores you want to use.
+
+```puppet
+class { 'nodejs':
+  version   => 'stable',
+  cpu_cores => 2,
+}
+```
+
 ### Configuring $NODE_PATH
 
 The environment variable $NODE_PATH can be configured using the `init` manifest:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,9 @@
 # [*python_package*]
 #   Python package name, defaults to python
 #
+# [*cpu_cores*]
+#   Number of CPU cores to use for compiling nodejs. Will be used for parallel 'make' jobs.
+#
 # == Example:
 #
 #  include nodejs
@@ -31,8 +34,10 @@ class nodejs(
   $make_install   = true,
   $node_path      = '/usr/local/node/node-default/lib/node_modules',
   $python_package = 'python',
+  $cpu_cores      = $::processorcount,
 ) {
   validate_string($node_path)
+  validate_integer($cpu_cores)
 
   $node_version = $version ? {
     undef    => nodejs_stable_version(),
@@ -46,6 +51,7 @@ class nodejs(
     target_dir     => $target_dir,
     make_install   => $make_install,
     python_package => $python_package,
+    cpu_cores      => $cpu_cores,
   }
 
   $nodejs_version_path = "/usr/local/node/node-${$node_version}"
@@ -61,13 +67,13 @@ class nodejs(
   $node_default_symlink_target = "${nodejs_default_path}/bin/node"
   $npm_default_symlink = "${target_dir}/npm"
   $npm_default_symlink_target = "${nodejs_default_path}/bin/npm"
-  
+
   file { $node_default_symlink:
     ensure  => link,
     target  => $node_default_symlink_target,
     require => File[$nodejs_default_path]
   }
-  
+
   file { $npm_default_symlink:
     ensure  => link,
     target  => $npm_default_symlink_target,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,6 +17,9 @@
 # [*python_package*]
 #   Python package name, defaults to python
 #
+# [*cpu_cores*]
+#   Number of CPU cores to use for compiling nodejs. Will be used for parallel 'make' jobs.
+#
 # == Example:
 #
 #  class { 'nodejs':
@@ -33,7 +36,9 @@ define nodejs::install (
   $target_dir     = undef,
   $make_install   = true,
   $python_package = 'python',
+  $cpu_cores      = $::processorcount,
 ) {
+  validate_integer($cpu_cores)
 
   include nodejs::params
 
@@ -173,7 +178,7 @@ define nodejs::install (
       ensure_packages([ $python_package, $gplusplus_package, 'make' ])
 
       exec { "nodejs-make-install-${node_version}":
-        command => "./configure --prefix=${node_unpack_folder} && make && make install",
+        command => "./configure --prefix=${node_unpack_folder} && make -j ${cpu_cores} && make -j ${cpu_cores} install",
         path    => "${node_unpack_folder}:/usr/bin:/bin:/usr/sbin:/sbin",
         cwd     => $node_unpack_folder,
         user    => 'root',

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -4,9 +4,10 @@ describe 'nodejs', :type => :class do
   let(:title) { 'nodejs' }
 
   let(:facts) {{
-    :kernel        => 'linux',
-    :hardwaremodel => 'x86',
-    :osfamily      => 'Ubuntu',
+    :kernel         => 'linux',
+    :hardwaremodel  => 'x86',
+    :osfamily       => 'Ubuntu',
+    :processorcount => 2,
   }}
 
   before(:each) {

--- a/spec/defines/nodejs_install_spec.rb
+++ b/spec/defines/nodejs_install_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 describe 'nodejs::install', :type => :define do
   let(:title) { 'nodejs::install' }
   let(:facts) {{
-    :kernel        => 'linux',
-    :hardwaremodel => 'x86',
-    :osfamily      => 'Ubuntu',
+    :kernel         => 'linux',
+    :hardwaremodel  => 'x86',
+    :osfamily       => 'Ubuntu',
+    :processorcount => 2,
   }}
 
   before(:each) {
@@ -49,7 +50,7 @@ describe 'nodejs::install', :type => :define do
     }
 
     it { should contain_exec('nodejs-make-install-v6.0.0') \
-      .with_command('./configure --prefix=/usr/local/node/node-v6.0.0 && make && make install') \
+      .with_command('./configure --prefix=/usr/local/node/node-v6.0.0 && make -j 2 && make -j 2 install') \
       .with_cwd('/usr/local/node/node-v6.0.0') \
       .with_unless('test -f /usr/local/node/node-v6.0.0/bin/node')
     }
@@ -72,6 +73,19 @@ describe 'nodejs::install', :type => :define do
 
     it { should_not contain_nodejs__install__download('npm-download-v6.0.0') }
     it { should_not contain_exec('npm-install-v6.0.0') }
+  end
+
+  describe 'default parameters with cpu_cores set manually to 1' do
+
+    let(:params) {{
+      :cpu_cores => 1
+    }}
+
+    it { should contain_exec('nodejs-make-install-v6.0.0') \
+      .with_command('./configure --prefix=/usr/local/node/node-v6.0.0 && make -j 1 && make -j 1 install') \
+      .with_cwd('/usr/local/node/node-v6.0.0') \
+      .with_unless('test -f /usr/local/node/node-v6.0.0/bin/node')
+    }
   end
 
   describe 'with specific version v6.0.0' do
@@ -105,7 +119,7 @@ describe 'nodejs::install', :type => :define do
     }
 
     it { should contain_exec('nodejs-make-install-v6.0.0') \
-      .with_command('./configure --prefix=/usr/local/node/node-v6.0.0 && make && make install') \
+      .with_command('./configure --prefix=/usr/local/node/node-v6.0.0 && make -j 2 && make -j 2 install') \
       .with_cwd('/usr/local/node/node-v6.0.0') \
       .with_unless('test -f /usr/local/node/node-v6.0.0/bin/node')
     }
@@ -130,6 +144,20 @@ describe 'nodejs::install', :type => :define do
     it { should_not contain_exec('npm-install-v6.0.0') }
   end
 
+  describe 'specific version v6.0.0 and cpu_cores manually set to 1' do
+
+    let(:params) {{
+      :version   => 'v6.0.0',
+      :cpu_cores => 1,
+    }}
+
+    it { should contain_exec('nodejs-make-install-v6.0.0') \
+      .with_command('./configure --prefix=/usr/local/node/node-v6.0.0 && make -j 1 && make -j 1 install') \
+      .with_cwd('/usr/local/node/node-v6.0.0') \
+      .with_unless('test -f /usr/local/node/node-v6.0.0/bin/node')
+    }
+  end
+
   describe 'with a given target_dir' do
     let(:params) {{
       :target_dir => '/bin'
@@ -152,9 +180,10 @@ describe 'nodejs::install', :type => :define do
 
   describe 'on a RedHat based OS (osfamily = RedHat)' do
     let(:facts) {{
-      :osfamily      => 'RedHat',
-      :kernel        => 'linux',
-      :hardwaremodel => 'x86',
+      :osfamily       => 'RedHat',
+      :kernel         => 'linux',
+      :hardwaremodel  => 'x86',
+      :processorcount => 2,
     }}
     let(:params) {{
       :version => 'v6.0.0'
@@ -167,9 +196,10 @@ describe 'nodejs::install', :type => :define do
 
   describe 'on a OpenSuse based OS (osfamily = Suse)' do
     let(:facts) {{
-      :osfamily      => 'Suse',
-      :kernel        => 'linux',
-      :hardwaremodel => 'x86',
+      :osfamily       => 'Suse',
+      :kernel         => 'linux',
+      :hardwaremodel  => 'x86',
+      :processorcount => 2,
     }}
     let(:params) {{
       :version => 'v6.0.0'
@@ -182,9 +212,10 @@ describe 'nodejs::install', :type => :define do
 
   describe 'on a Non-RedHat based OS (osfamily != RedHat)' do
     let(:facts) {{
-      :osfamily      => 'Debian',
-      :kernel        => 'linux',
-      :hardwaremodel => 'x86',
+      :osfamily       => 'Debian',
+      :kernel         => 'linux',
+      :hardwaremodel  => 'x86',
+      :processorcount => 2,
     }}
     let(:params) {{
       :version => 'v6.0.0'
@@ -202,7 +233,8 @@ describe 'nodejs::install', :type => :define do
         :ensure  => 'absent',
       }}
       let(:facts) {{
-        :nodejs_installed_version => 'v0.12'
+        :nodejs_installed_version => 'v0.12',
+        :processorcount           => 2,
       }}
 
       it { should contain_file('/usr/local/node/node-v0.12') \
@@ -216,7 +248,8 @@ describe 'nodejs::install', :type => :define do
 
     describe 'default instance' do
       let(:facts) {{
-        :nodejs_installed_version => 'v5.6.0'
+        :nodejs_installed_version => 'v5.6.0',
+        :processorcount           => 2,
       }}
       let(:params) {{
         :version => 'v5.6.0',

--- a/spec/defines/nodejs_npm_spec.rb
+++ b/spec/defines/nodejs_npm_spec.rb
@@ -3,10 +3,11 @@ require 'spec_helper'
 describe 'nodejs::npm', :type => :define do
   let(:title) { 'nodejs::npm' }
   let(:facts) {{
-    :kernel        => 'linux',
-    :hardwaremodel => 'x86',
-    :osfamily      => 'Ubuntu',
-    :path          => '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin'
+    :kernel         => 'linux',
+    :hardwaremodel  => 'x86',
+    :osfamily       => 'Ubuntu',
+    :path           => '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin',
+    :processorcount => 2,
   }}
 
   describe 'install npm package' do
@@ -64,7 +65,8 @@ describe 'nodejs::npm', :type => :define do
         :osfamily        => os,
         :hardwaremodel   => 'x86',
         :kernel          => 'linux',
-        :path            => '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin'
+        :path            => '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin',
+        :processorcount  => 2,
       }}
 
       it { should contain_exec('npm_install_yo_/foo') \


### PR DESCRIPTION
### Overview

This PR adds an option to make use of multi-core systems by enabling the make and make install commands to use (by default) all available cpu cores as the parallel jobs option to speed up the compile process. The user can also customize that to any number.