### PR TITLE
Changed nodejs download and other URLs from HTTP to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ puppet-nodejs
 [![Build
 Status](https://travis-ci.org/willdurand/puppet-nodejs.png?branch=master)](https://travis-ci.org/willdurand/puppet-nodejs)
 
-This module allows you to install [Node.js](http://nodejs.org/) and
+This module allows you to install [Node.js](https://nodejs.org/) and
 [NPM](https://npmjs.org/). This module is published on the Puppet Forge as
-[willdurand/nodejs](http://forge.puppetlabs.com/willdurand/nodejs).
+[willdurand/nodejs](https://forge.puppetlabs.com/willdurand/nodejs).
 
 Version 1.9
 -----------
@@ -54,7 +54,7 @@ class { 'nodejs':
 ```
 This will compile and install Node.js version `v6.0.0` to your machine. `node` and `npm` will be available in your `$PATH` via `/usr/local/node/node-default/bin` so you can just start using `node`.
 
-Shortcuts are provided to easily install the `latest` or `stable` release by setting the `version` parameter to `latest` or `stable`. It will automatically look for the last release available on http://nodejs.org.
+Shortcuts are provided to easily install the `latest` or `stable` release by setting the `version` parameter to `latest` or `stable`. It will automatically look for the last release available on https://nodejs.org.
 
 ```puppet
 class { 'nodejs':
@@ -64,7 +64,7 @@ class { 'nodejs':
 
 ### Setup using the pre-built installer
 
-To use the pre-built installer version provided via http://nodejs.org/download you have to set `make_install` to `false`
+To use the pre-built installer version provided via https://nodejs.org/download you have to set `make_install` to `false`
 
 ```puppet
 class { 'nodejs':
@@ -237,7 +237,7 @@ export http_proxy=http://myHttpProxy:8888
 Running the tests
 -----------------
 
-Install the dependencies using [Bundler](http://gembundler.com):
+Install the dependencies using [Bundler](https://bundler.io):
 
     bundle install
 

--- a/lib/puppet/parser/functions/nodejs_functions.rb
+++ b/lib/puppet/parser/functions/nodejs_functions.rb
@@ -32,7 +32,7 @@ def get_version_list
     return NodeJSListStore::get_list
   end
 
-  uri = URI('http://nodejs.org/dist/')
+  uri = URI('https://nodejs.org/dist/')
 
   http_proxy = ENV["http_proxy"]
   if http_proxy.to_s != ''

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -126,7 +126,7 @@ define nodejs::install (
     })
 
     ::nodejs::install::download { "nodejs-download-${node_version}":
-      source      => "http://nodejs.org/dist/${node_version}/${node_filename}",
+      source      => "https://nodejs.org/dist/${node_version}/${node_filename}",
       destination => "${::nodejs::params::install_dir}/${node_filename}",
       require     => File['nodejs-install-dir'],
     }

--- a/spec/defines/nodejs_install_spec.rb
+++ b/spec/defines/nodejs_install_spec.rb
@@ -30,7 +30,7 @@ describe 'nodejs::install', :type => :define do
     }
 
     it { should contain_nodejs__install__download('nodejs-download-v6.0.0') \
-      .with_source('http://nodejs.org/dist/v6.0.0/node-v6.0.0.tar.gz') \
+      .with_source('https://nodejs.org/dist/v6.0.0/node-v6.0.0.tar.gz') \
       .with_destination('/usr/local/node/node-v6.0.0.tar.gz')
     }
 
@@ -99,7 +99,7 @@ describe 'nodejs::install', :type => :define do
     }
 
     it { should contain_nodejs__install__download('nodejs-download-v6.0.0') \
-      .with_source('http://nodejs.org/dist/v6.0.0/node-v6.0.0.tar.gz') \
+      .with_source('https://nodejs.org/dist/v6.0.0/node-v6.0.0.tar.gz') \
       .with_destination('/usr/local/node/node-v6.0.0.tar.gz')
     }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,7 @@ HTML
 
 RSpec.configure do |config|
   config.before(:each) do
-    stub_request(:get, "http://nodejs.org/dist/")
+    stub_request(:get, "http://nodejs.org:443/dist/")
       .to_return(:status => 200, :body => nodejs_response, :headers => {})
   end
 end


### PR DESCRIPTION
I've seen that nodejs source or binary are being downloaded with HTTP which is probably bad since you don't have authenticity that you really download it from nodejs.org (MITM) especially in countries with restrictive goverments or ISPs. The module should always use HTTPS to gain confidence that you have downloaded what you intended to and that is has not been modified in between.