### PR TITLE
Enable SSL on the version list https request

### DIFF
--- a/lib/puppet/parser/functions/nodejs_functions.rb
+++ b/lib/puppet/parser/functions/nodejs_functions.rb
@@ -45,6 +45,7 @@ def get_version_list
   else
     request = Net::HTTP.new(uri.host, uri.port)
   end
+  request.use_ssl = (uri.scheme == 'https')
   request.open_timeout = 2
   request.read_timeout = 2
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,7 @@ HTML
 
 RSpec.configure do |config|
   config.before(:each) do
-    stub_request(:get, "http://nodejs.org:443/dist/")
+    stub_request(:get, "https://nodejs.org:443/dist/")
       .to_return(:status => 200, :body => nodejs_response, :headers => {})
   end
 end


### PR DESCRIPTION
### Overview

`get_version_list` connects to https://nodejs.org/dist/ using the http protocol. So the server returns an error (`400 The plain HTTP request was sent to HTTPS port`), `get_version_list` returns an empty array and `get_stable_version` raises a confusing exception (`can't convert nil into String`).

This change makes the function connect using the https protocol.

### Related issues

Introduced in #162.