### PR TITLE
fix for #174: create `npmrc` containing prefix to build package symlinks properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.1.0
 
 env:
-  - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.6.0"
   - PUPPET_VERSION="~> 3.7.0"
   - PUPPET_VERSION="~> 4.3.0"

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require 'puppet_blacksmith/rake_tasks'
 PuppetLint.configuration.log_format       = "%{path}:%{line}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = false
 PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.send("disable_arrow_on_right_operand_line")
 
 exclude_paths = [
   "pkg/**/*",

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -130,6 +130,17 @@ define nodejs::instance($ensure, $version, $target_dir, $make_install, $cpu_core
       }
     }
 
+    $node_prefix = "${target_dir}"
+    file { "nodejs-npmrc-etc-dir-${version}":
+      ensure => directory,
+      path   =>  "${node_unpack_folder}/etc",
+    } ->
+    file { "nodejs-npmrc-${version}":
+      ensure  => present,
+      path    => "${node_unpack_folder}/etc/npmrc",
+      content => template("${module_name}/npmrc")
+    }
+
     file { "nodejs-symlink-bin-with-version-${version}":
       ensure => 'link',
       path   => $node_symlink,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -130,7 +130,7 @@ define nodejs::instance($ensure, $version, $target_dir, $make_install, $cpu_core
       }
     }
 
-    $node_prefix = "${target_dir}"
+    $node_prefix = $target_dir
     file { "nodejs-npmrc-etc-dir-${version}":
       ensure => directory,
       path   =>  "${node_unpack_folder}/etc",

--- a/spec/defines/nodejs_instance_spec.rb
+++ b/spec/defines/nodejs_instance_spec.rb
@@ -112,6 +112,15 @@ describe 'nodejs::instance', :type => :define do
       .with_content(/(.*)\/usr\/local\/bin\/node-v6.0.0 \/usr\/local\/node\/node-v6.0.0\/bin\/npm "\$@"/)
     }
 
+    it { should contain_file('nodejs-npmrc-etc-dir-v6.0.0') \
+      .with_ensure('directory') \
+      .with_path('/usr/local/node/node-v6.0.0/etc')
+    }
+
+    it { should contain_file('nodejs-npmrc-v6.0.0') \
+      .with_path('/usr/local/node/node-v6.0.0/etc/npmrc')
+    }
+
     it { should_not contain_file('/usr/local/bin/node') }
     it { should_not contain_file('/usr/local/bin/npm') }
 

--- a/templates/npmrc
+++ b/templates/npmrc
@@ -1,0 +1,1 @@
+prefix=<%= @node_prefix.sub! '/bin', '' %>

--- a/templates/npmrc
+++ b/templates/npmrc
@@ -1,1 +1,1 @@
-prefix=<%= @node_prefix.sub! '/bin', '' %>
+prefix=<%= @node_prefix.sub '/bin', '' %>


### PR DESCRIPTION
see #174 
