### PR TITLE
Fixing dependency for rubygems

### DIFF
--- a/manifests/instance/pkgs.pp
+++ b/manifests/instance/pkgs.pp
@@ -16,7 +16,7 @@ class nodejs::instance::pkgs($make_install = false) {
     warning('nodejs::instance::pkgs is private!')
   }
 
-  ensure_packages(['tar', 'wget', 'ruby'])
+  ensure_packages(['tar', 'wget', 'ruby', 'rubygems'])
   ensure_packages(['semver'], {
     provider => gem,
     require  => Package['ruby'],


### PR DESCRIPTION
### Overview

Fixes: Error: /Stage[main]/Nodejs::Instance::Pkgs/Package[semver]: Provider gem is not functional on this host

The semver gem requires rubygems to be installed.


### Related issues

