### PR TITLE
Preparation for 2.1

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,7 @@ fixtures:
   repositories:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref: "4.12.0"
+      ref: "5.1.0"
     gcc:
       repo: "git://github.com/puppetlabs/puppetlabs-gcc.git"
       ref: "0.3.0"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,3 @@ fixtures:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
       ref: "5.1.0"
-    gcc:
-      repo: "git://github.com/puppetlabs/puppetlabs-gcc.git"
-      ref: "0.3.0"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,15 @@
+# RSpec
 spec/fixtures/
+/coverage
+
+# Puppet
 pkg/
+
+# Bundler
 Gemfile.lock
 /.bundle/
 /vendor/
-/coverage
+
+# Beaker
+log/
+junit/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - PUPPET_VERSION="~> 4.10.12" STRICT_VARIABLES=yes RUBY_VERSION="2.4.0" TARGET=test
   - PUPPET_VERSION="~> 5.5.1" RUBY_VERSION="2.4.0" TARGET=test
   - PUPPET_VERSION="~> 6.0.3" RUBY_VERSION="2.5.1" TARGET=test
+  - TARGET=acceptance RUBY_VERSION="2.5.1" BEAKER_setfile=spec/acceptance/nodesets/ubuntu-1604-x64.yml
 
 before_install:
   - gem update bundler
@@ -17,3 +18,5 @@ before_install:
 script: "rake $TARGET"
 
 sudo: false
+
+services: docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This document lists the changes of all recent versions since `2.0.0`.
 * Don't install dev dependencies (`ruby`) anymore with `build_deps => true`. It's only needed on
   the Puppet Master and shouldn't be deployed onto each node.
 
+### Further changes
+
+* Deprecated `::nodejs::npm`. The feature was always out of scope and introduced several hacks
+  to support several edge-cases. Instead it's recommended to write a custom module suited
+  for your application when deploying dependencies into a given directory.
+
 ## 2.0.3
 
 * ([#184](https://github.com/willdurand/puppet-nodejs/issues/184)) Added support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This document lists the changes of all recent versions since `2.0.0`.
 
+## 2.1.0
+
+### Minor breaking changes
+
+* Dropped EOLed Puppet 3.x
+* Don't install dev dependencies (`ruby`) anymore with `build_deps => true`. It's only needed on
+  the Puppet Master and shouldn't be deployed onto each node.
+
 ## 2.0.3
 
 * ([#184](https://github.com/willdurand/puppet-nodejs/issues/184)) Added support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This document lists the changes of all recent versions since `2.0.0`.
 * Don't install dev dependencies (`ruby`) anymore with `build_deps => true`. It's only needed on
   the Puppet Master and shouldn't be deployed onto each node.
 
+### Other notable changes
+
+* ([#185](https://github.com/willdurand/puppet-nodejs/issues/185)) Allow to specify a custom source
+  for NodeJS to override `nodejs.org/dist`.
+
 ### Further changes
 
 * Deprecated `::nodejs::npm`. The feature was always out of scope and introduced several hacks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This document lists the changes of all recent versions since `2.0.0`.
 
 * ([#185](https://github.com/willdurand/puppet-nodejs/issues/185)) Allow to specify a custom source
   for NodeJS to override `nodejs.org/dist`.
+* Don't depend on `puppetlabs-gcc` anymore. It wasn't updated by PuppetLabs since 2015
+  and according to its metadata it doesn't support recent Puppet version which breaks the
+  `beaker` build.
 
 ### Further changes
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,6 @@ group :devel do
   gem 'coveralls', require: false
 
   gem 'rubocop'
+
+  gem 'metadata-json-lint'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -21,3 +21,12 @@ group :devel do
 
   gem 'metadata-json-lint'
 end
+
+group :beaker do
+  gem 'beaker'
+  gem 'beaker-rspec'
+  gem 'beaker-puppet'
+  gem 'beaker-docker'
+  gem 'beaker-puppet_install_helper'
+  gem 'beaker-module_install_helper'
+end

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ This module allows you to install [Node.js](https://nodejs.org/) and
 The module depends on the following well-adopted and commonly used modules:
 
 * [puppetlabs/stdlib](https://github.com/puppetlabs/puppetlabs-stdlib)
-* [puppetlabs/gcc](https://github.com/puppetlabs/puppetlabs-gcc)
 
 The easiest approach to install this module is by using [r10k](https://github.com/puppetlabs/r10k):
 
@@ -33,7 +32,6 @@ forge 'http://forge.puppetlabs.com'
 
 mod 'willdurand/nodejs', '2.0.3'
 mod 'puppetlabs/stdlib', '5.1.0'
-mod 'puppetlabs/gcc', '0.3.0'
 ```
 
 The Puppet Master which evaluates the catalogue before deploying each node requires
@@ -303,7 +301,11 @@ The easiest way to get started is using [`bundler`](https://bundler.io):
 ```
 bundle install
 bundle exec rake test
+PUPPET_INSTALL_TYPE=agent BEAKER_setfile=spec/acceptance/nodesets/ubuntu-1604-x64.yml bundle exec rake acceptance
 ```
+
+**Note:** to run the acceptance tests that are part of rake's `test` target,
+[Docker](https://www.docker.com/) is required.
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,15 @@ package { 'express':
 }
 ```
 
-### NPM installer
+### NPM installer (deprecated)
+
+Note: this API is deprecated and will be removed in `3.0`. It's recommended to either package your
+applications properly using `npm` and install them as package using the `npm` provider or to directly
+run `npm install` when deploying your application (e.g. with a custom Puppet module).
+
+This module is focused on setting up an environment with `nodejs`, application deployment should be handled
+in its own module. In the end this was just a wrapper on top of `npm` which runs an `exec` with
+`npm install` and a configurable user and lacks proper `ensure => absent` support.
 
 The `nodejs` installer can be used if a npm package should not be installed globally, but in a
 certain directory.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This module allows you to install [Node.js](https://nodejs.org/) and
 [willdurand/nodejs](https://forge.puppetlabs.com/willdurand/nodejs).
 
 ### Announcements
-
 * From now on `2.0` is maintenance-only and accepts bugfixes until `2.2` is released. On `master`
   the active development on `2.1` is currently happening. The docs of `2.0` can be found
   [here](https://github.com/willdurand/puppet-nodejs/tree/2.0#puppet-nodejs)
@@ -74,6 +73,28 @@ In order to compile from source with `gcc`, the `make_install` option must be `t
 ```puppet
 class { 'nodejs':
   version      => 'lts',
+  make_install => true,
+}
+```
+
+### Using a custom source
+
+It's also possible to deploy NodeJS instances to Puppet nodes from your own server.
+This can be helpful when e.g. distributing your own, patched version of NodeJS.
+
+The source can be specified like this:
+
+``` puppet
+class { '::nodejs':
+  source => 'https://example.org/dist-nodejs',
+}
+```
+
+It's also possible to compile the custom instance from source:
+
+``` puppet
+class { '::nodejs':
+  source       => 'https://example.org/src-nodejs',
   make_install => true,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ mod 'puppetlabs/stdlib', '5.1.0'
 mod 'puppetlabs/gcc', '0.3.0'
 ```
 
+The Puppet Master which evaluates the catalogue before deploying each node requires
+the following modules to properly evaluate the functions bundled with this module:
+
+* [semver](https://rubygems.org/gems/semver/versions/1.0.1)
+
 ## Usage
 
 ### Deploying a precompiled package
@@ -258,9 +263,7 @@ class { '::nodejs':
 In this case you'll need to take care of the following packages:
 
 - `tar`
-- `ruby`
 - `wget`
-- `semver` (GEM used by ruby)
 - `make` (if `make_install` = `true`)
 - `gcc` compiler (if `make_install` = `true`)
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,9 @@ require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks'
 require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new
+RuboCop::RakeTask.new(:rubocop_local) do |t|
+  t.options = ['-c', '.rubocop.yml']
+end
 
 PuppetLint.configuration.log_format       = "%{path}:%{line}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = false
@@ -23,7 +25,7 @@ PuppetSyntax.exclude_paths            = exclude_paths
 desc "Run syntax, lint, and spec tests."
 task :test => [
   :metadata_lint,
-  :rubocop,
+  :rubocop_local,
   :syntax,
   :lint,
   :spec,

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,12 @@ exclude_paths = [
 PuppetLint.configuration.ignore_paths = exclude_paths
 PuppetSyntax.exclude_paths            = exclude_paths
 
-desc "Run syntax, lint, and spec tests."
+desc "Run acceptance with beaker"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
+end
+
+desc "Run syntax, lint, spec and acceptance tests."
 task :test => [
   :metadata_lint,
   :rubocop_local,

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ PuppetSyntax.exclude_paths            = exclude_paths
 
 desc "Run syntax, lint, and spec tests."
 task :test => [
+  :metadata_lint,
   :rubocop,
   :syntax,
   :lint,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,7 +57,7 @@ class nodejs(
   String $install_dir                = $::nodejs::params::install_dir,
   Optional[String] $source           = $::nodejs::params::source,
 ) inherits ::nodejs::params  {
-  $node_version        = evaluate_version($version)
+  $node_version = evaluate_version($version)
 
   if $build_deps {
     Anchor['nodejs::start'] ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,26 +38,16 @@
 #  }
 #
 class nodejs(
-  $version             = $::nodejs::params::version,
-  $target_dir          = $::nodejs::params::target_dir,
-  $make_install        = $::nodejs::params::make_install,
-  $node_path           = $::nodejs::params::node_path,
-  $cpu_cores           = $::nodejs::params::cpu_cores,
-  $instances           = $::nodejs::params::instances,
-  $instances_to_remove = $::nodejs::params::instances_to_remove,
-  $download_timeout    = $::nodejs::params::download_timeout,
-  $build_deps          = $::nodejs::params::build_deps,
+  String $version                    = $::nodejs::params::version,
+  String $target_dir                 = $::nodejs::params::target_dir,
+  Boolean $make_install              = $::nodejs::params::make_install,
+  String $node_path                  = $::nodejs::params::node_path,
+  Integer $cpu_cores                 = $::nodejs::params::cpu_cores,
+  Hash[String, Hash] $instances      = $::nodejs::params::instances,
+  Array[String] $instances_to_remove = $::nodejs::params::instances_to_remove,
+  Integer $download_timeout          = $::nodejs::params::download_timeout,
+  Boolean $build_deps                = $::nodejs::params::build_deps,
 ) inherits ::nodejs::params  {
-  validate_string($node_path)
-  validate_integer($cpu_cores)
-  validate_string($version)
-  validate_string($target_dir)
-  validate_bool($make_install)
-  validate_hash($instances)
-  validate_array($instances_to_remove)
-  validate_integer($download_timeout)
-  validate_bool($build_deps)
-
   $node_version        = evaluate_version($version)
   $nodejs_default_path = '/usr/local/node/node-default'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,9 @@
 # [*build_deps*]
 #   Optional parameter whether or not to allow the module to installs its dependant packages.
 #
+# [*install_dir*]
+#   Installation directory for all node instances. By default `/usr/local/node`.
+#
 # == Example:
 #
 #  include nodejs
@@ -48,6 +51,7 @@ class nodejs(
   Integer $download_timeout          = $::nodejs::params::download_timeout,
   Boolean $build_deps                = $::nodejs::params::build_deps,
   String $nodejs_default_path        = $::nodejs::params::nodejs_default_path,
+  String $install_dir                = $::nodejs::params::install_dir,
 ) inherits ::nodejs::params  {
   $node_version        = evaluate_version($version)
 
@@ -68,6 +72,7 @@ class nodejs(
       instances_to_remove => $instances_to_remove,
       nodejs_default_path => $nodejs_default_path,
       download_timeout    => $download_timeout,
+      install_dir         => $install_dir,
     } ->
     # TODO remove!
     file { '/etc/profile.d/nodejs.sh':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,9 +47,9 @@ class nodejs(
   Array[String] $instances_to_remove = $::nodejs::params::instances_to_remove,
   Integer $download_timeout          = $::nodejs::params::download_timeout,
   Boolean $build_deps                = $::nodejs::params::build_deps,
+  String $nodejs_default_path        = $::nodejs::params::nodejs_default_path,
 ) inherits ::nodejs::params  {
   $node_version        = evaluate_version($version)
-  $nodejs_default_path = '/usr/local/node/node-default'
 
   if $build_deps {
     Anchor['nodejs::start'] ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,9 @@
 # [*install_dir*]
 #   Installation directory for all node instances. By default `/usr/local/node`.
 #
+# [*source*]
+#   Which source to use instead of `nodejs.org/dist`. Optional parameter, `undef` by default.
+#
 # == Example:
 #
 #  include nodejs
@@ -52,6 +55,7 @@ class nodejs(
   Boolean $build_deps                = $::nodejs::params::build_deps,
   String $nodejs_default_path        = $::nodejs::params::nodejs_default_path,
   String $install_dir                = $::nodejs::params::install_dir,
+  Optional[String] $source           = $::nodejs::params::source,
 ) inherits ::nodejs::params  {
   $node_version        = evaluate_version($version)
 
@@ -73,6 +77,7 @@ class nodejs(
       nodejs_default_path => $nodejs_default_path,
       download_timeout    => $download_timeout,
       install_dir         => $install_dir,
+      source              => $source,
     } ->
     # TODO remove!
     file { '/etc/profile.d/nodejs.sh':

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -23,18 +23,18 @@
 # [*timeout*]
 #   Maximum download timeout.
 #
-define nodejs::instance($ensure, $version, $target_dir, $make_install, $cpu_cores, $default_node_version, $timeout) {
+define nodejs::instance(
+  Pattern[/^present|absent$/] $ensure,
+  String $version,
+  String $target_dir,
+  Boolean $make_install,
+  Integer $cpu_cores,
+  Optional[String] $default_node_version,
+  Integer $timeout
+) {
   if $caller_module_name != $module_name {
     warning('nodejs::instance is private!')
   }
-
-  validate_string($ensure)
-  validate_re($ensure, '^(present|absent)$')
-  validate_integer($cpu_cores)
-  validate_string($version)
-  validate_string($target_dir)
-  validate_bool($make_install)
-  validate_integer($timeout)
 
   include ::nodejs::params
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -23,6 +23,9 @@
 # [*timeout*]
 #   Maximum download timeout.
 #
+# [*source*]
+#   Which source to use instead of `nodejs.org/dist`. Optional parameter, `undef` by default.
+#
 define nodejs::instance(
   Pattern[/^present|absent$/] $ensure,
   String $version,
@@ -31,7 +34,8 @@ define nodejs::instance(
   Integer $cpu_cores,
   Optional[String] $default_node_version,
   Integer $timeout,
-  String $install_dir
+  String $install_dir,
+  Optional[String] $source = undef,
 ) {
   if $caller_module_name != $module_name {
     warning('nodejs::instance is private!')
@@ -70,8 +74,13 @@ define nodejs::instance(
       mode   => '0644',
     })
 
+    $download_source = $source ? {
+      undef   => "https://nodejs.org/dist/${version}/${node_filename}",
+      default => $source,
+    }
+
     ::nodejs::instance::download { "nodejs-download-${version}":
-      source      => "https://nodejs.org/dist/${version}/${node_filename}",
+      source      => $download_source,
       destination => "${install_dir}/${node_filename}",
       require     => File['nodejs-install-dir'],
       timeout     => $timeout,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -131,8 +131,7 @@ define nodejs::instance(
         timeout => 0,
         require => [
           Exec["nodejs-unpack-${version}"],
-          Class['::gcc'],
-          Package['make'],
+          Class['::nodejs::instance::pkgs'],
         ],
         before  => File["nodejs-symlink-bin-with-version-${version}"],
       }

--- a/manifests/instance/download.pp
+++ b/manifests/instance/download.pp
@@ -15,16 +15,11 @@
 #   Timeout for the download command.
 #
 define nodejs::instance::download(
-  $source,
-  $destination,
-  $unless_test = true,
-  $timeout     = 0
+  String $source,
+  String $destination,
+  Boolean $unless_test = true,
+  Integer $timeout     = 0
 ) {
-  validate_bool($unless_test)
-  validate_string($destination)
-  validate_string($source)
-  validate_integer($timeout)
-
   if $caller_module_name != $module_name {
     warning('::nodejs::install::download is not meant for public use!')
   }

--- a/manifests/instance/pkgs.pp
+++ b/manifests/instance/pkgs.pp
@@ -11,21 +11,12 @@
 #
 # class { '::nodejs::instance::pkgs': }
 #
-class nodejs::instance::pkgs($make_install = false) {
+class nodejs::instance::pkgs(Boolean $make_install = false) {
   if $caller_module_name != $module_name {
     warning('nodejs::instance::pkgs is private!')
   }
 
-  $rubygems = $::osfamily ? {
-    'Debian' => 'rubygems-integration',
-    default  => 'rubygems'
-  }
-
-  ensure_packages(['tar', 'wget', 'ruby', $rubygems])
-  ensure_packages(['semver'], {
-    provider => gem,
-    require  => Package['ruby'],
-  })
+  ensure_packages(['tar', 'wget'])
 
   if $make_install {
     include ::gcc

--- a/manifests/instance/pkgs.pp
+++ b/manifests/instance/pkgs.pp
@@ -19,7 +19,15 @@ class nodejs::instance::pkgs(Boolean $make_install = false) {
   ensure_packages(['tar', 'wget'])
 
   if $make_install {
-    include ::gcc
+    # inherited from https://github.com/puppetlabs/puppetlabs-gcc/blob/master/manifests/params.pp,
+    # but the module is abandoned and only supports Puppet3.
+    $gcc_packages = $::osfamily ? {
+      'RedHat' => ['gcc', 'gcc-g++'],
+      'Debian' => ['gcc', 'build-essential'],
+      default  => fail("Class['::nodejs::instances::pkgs']: unsupported osfamily: ${::osfamily}")
+    }
+
+    ensure_packages($gcc_packages)
     ensure_packages(['make'])
   }
 }

--- a/manifests/instances.pp
+++ b/manifests/instances.pp
@@ -26,7 +26,16 @@
 # [*download_timeout*]
 #   Maximum time for the download of the nodejs sources.
 #
-class nodejs::instances($instances, $node_version, $target_dir, $make_install, $cpu_cores, $instances_to_remove, $nodejs_default_path, $download_timeout) {
+class nodejs::instances(
+  Hash[String, Hash] $instances,
+  String $node_version,
+  String $target_dir,
+  Boolean $make_install,
+  Integer $cpu_cores,
+  Array[String] $instances_to_remove,
+  String $nodejs_default_path,
+  Integer $download_timeout
+) {
   if $caller_module_name != $module_name {
     warning('nodejs::instances is private!')
   }

--- a/manifests/instances.pp
+++ b/manifests/instances.pp
@@ -34,7 +34,8 @@ class nodejs::instances(
   Integer $cpu_cores,
   Array[String] $instances_to_remove,
   String $nodejs_default_path,
-  Integer $download_timeout
+  Integer $download_timeout,
+  String $install_dir,
 ) {
   if $caller_module_name != $module_name {
     warning('nodejs::instances is private!')
@@ -49,6 +50,7 @@ class nodejs::instances(
       cpu_cores            => $cpu_cores,
       default_node_version => undef,
       timeout              => $download_timeout,
+      install_dir          => $install_dir,
     }
   } else {
     create_resources('::nodejs::instance', node_instances($instances, true), {
@@ -58,6 +60,7 @@ class nodejs::instances(
       cpu_cores            => $cpu_cores,
       default_node_version => undef,
       timeout              => $download_timeout,
+      install_dir          => $install_dir,
     })
 
     if !defined(Nodejs::Instance["nodejs-custom-instance-${$node_version}"]) {
@@ -73,6 +76,7 @@ class nodejs::instances(
       target_dir           => $target_dir,
       default_node_version => $node_version,
       timeout              => $download_timeout,
+      install_dir          => $install_dir,
     })
   }
 

--- a/manifests/instances.pp
+++ b/manifests/instances.pp
@@ -26,6 +26,12 @@
 # [*download_timeout*]
 #   Maximum time for the download of the nodejs sources.
 #
+# [*install_dir*]
+#   Where to deploy the NodeJS instances into.
+#
+# [*source*]
+#  Where to fetch the NodeJS instances (either sources or binary distributions).
+#
 class nodejs::instances(
   Hash[String, Hash] $instances,
   String $node_version,
@@ -36,6 +42,7 @@ class nodejs::instances(
   String $nodejs_default_path,
   Integer $download_timeout,
   String $install_dir,
+  Optional[String] $source = undef,
 ) {
   if $caller_module_name != $module_name {
     warning('nodejs::instances is private!')
@@ -51,6 +58,7 @@ class nodejs::instances(
       default_node_version => undef,
       timeout              => $download_timeout,
       install_dir          => $install_dir,
+      source               => $source,
     }
   } else {
     create_resources('::nodejs::instance', node_instances($instances, true), {
@@ -61,6 +69,7 @@ class nodejs::instances(
       default_node_version => undef,
       timeout              => $download_timeout,
       install_dir          => $install_dir,
+      source               => $source,
     })
 
     if !defined(Nodejs::Instance["nodejs-custom-instance-${$node_version}"]) {
@@ -77,6 +86,7 @@ class nodejs::instances(
       default_node_version => $node_version,
       timeout              => $download_timeout,
       install_dir          => $install_dir,
+      source               => $source,
     })
   }
 

--- a/manifests/npm.pp
+++ b/manifests/npm.pp
@@ -56,6 +56,8 @@ define nodejs::npm (
   $options   = undef,
   $home_dir  = '/root',
 ) {
+  warning("::nodejs::npm is deprecated and will thus be removed in 3.0! Instead, package your applications directly with npm and use the npm provider or directly implement this directly in your application's puppet module.")
+
   validate_string($version)
   validate_string($exec_user)
   validate_bool($list)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,4 +25,5 @@ class nodejs::params {
   $download_timeout    = 0
   $build_deps          = true
   $nodejs_default_path = '/usr/local/node/node-default'
+  $source              = undef
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,4 +24,5 @@ class nodejs::params {
   $instances_to_remove = []
   $download_timeout    = 0
   $build_deps          = true
+  $nodejs_default_path = '/usr/local/node/node-default'
 }

--- a/metadata.json
+++ b/metadata.json
@@ -47,17 +47,13 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.12.0 <6.0"
-    },
-    {
-      "name": "puppetlabs/gcc",
-      "version_requirement": ">=0.3.0 <1.0"
+      "version_requirement": ">= 4.12.0 < 6.0.0"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.3.0 <7.0.0"
+      "version_requirement": ">= 4.3.0 < 7.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -47,11 +47,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=3.2.1"
+      "version_requirement": ">=4.12.0 <6.0"
     },
     {
       "name": "puppetlabs/gcc",
-      "version_requirement": ">=0.3.0"
+      "version_requirement": ">=0.3.0 <1.0"
     }
   ],
   "requirements": [

--- a/shell.nix
+++ b/shell.nix
@@ -5,4 +5,9 @@ mkShell {
   buildInputs = [
     ruby bundler rubocop
   ];
+
+  shellHook = ''
+    export PUPPET_INSTALL_TYPE=agent
+    export BEAKER_setfile=spec/acceptance/nodesets/ubuntu-1604-x64.yml
+  '';
 }

--- a/spec/acceptance/nodejs_spec.rb
+++ b/spec/acceptance/nodejs_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper_acceptance'
+
+describe 'nodejs acceptance test' do
+  context 'with default arguments' do
+    it 'compiles and applies the catalogue' do
+      pp = <<-EOS
+        class { '::nodejs': }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+  end
+end

--- a/spec/acceptance/nodesets/ubuntu-1604-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1604-x64.yml
@@ -1,0 +1,8 @@
+HOSTS:
+  ubuntu-16.04:
+    roles: [master]
+    hypervisor: docker
+    platform: ubuntu-16.04-amd64
+    image: ubuntu:16.04
+CONFIG:
+  type: foss

--- a/spec/classes/nodejs_instance_pkgs_spec.rb
+++ b/spec/classes/nodejs_instance_pkgs_spec.rb
@@ -9,14 +9,6 @@ describe 'nodejs::instance::pkgs', :type => :class do
   describe 'module dependency management' do
     it { should contain_package('wget') }
     it { should contain_package('tar') }
-    it { should contain_package('rubygems-integration') }
-  end
-
-  describe 'redhat OS' do
-    let(:facts) {{
-      :osfamily => 'RedHat',
-    }}
-    it { should contain_package('rubygems') }
   end
 
   describe 'includes compiler-related dependencies' do

--- a/spec/classes/nodejs_instance_pkgs_spec.rb
+++ b/spec/classes/nodejs_instance_pkgs_spec.rb
@@ -23,6 +23,6 @@ describe 'nodejs::instance::pkgs', :type => :class do
     it { should contain_package('tar') }
 
     it { should contain_package('make') }
-    it { should contain_class('gcc') }
+    it { should contain_package('gcc') }
   end
 end

--- a/spec/classes/nodejs_instances_spec.rb
+++ b/spec/classes/nodejs_instances_spec.rb
@@ -29,6 +29,7 @@ describe 'nodejs::instances', :type => :class do
       :cpu_cores           => 2,
       :nodejs_default_path => '/usr/local/node/node-default',
       :download_timeout    => 0,
+      :install_dir         => '/usr/local/node',
     }}
 
     it { should contain_nodejs__instance('nodejs-custom-instance-v5.0.0') \
@@ -55,6 +56,7 @@ describe 'nodejs::instances', :type => :class do
       :cpu_cores           => 2,
       :nodejs_default_path => '/usr/local/node/node-default',
       :download_timeout    => 0,
+      :install_dir         => '/usr/local/node',
     }}
 
     it { should contain_nodejs__instance("nodejs-custom-instance-v4.4.7") \
@@ -99,6 +101,7 @@ describe 'nodejs::instances', :type => :class do
       :instances_to_remove => [],
       :nodejs_default_path => '/usr/local/node/node-default',
       :download_timeout    => 0,
+      :install_dir         => '/usr/local/node',
     }}
 
     it { should contain_nodejs__instance("nodejs-custom-instance-v6.7.0") \
@@ -128,6 +131,7 @@ describe 'nodejs::instances', :type => :class do
       :instances_to_remove => ['v6.4.0'],
       :nodejs_default_path => '/usr/local/node/node-default',
       :download_timeout    => 0,
+      :install_dir         => '/usr/local/node',
     }}
 
     it { should contain_nodejs__instance("nodejs-uninstall-custom-v6.4.0") \
@@ -154,6 +158,7 @@ describe 'nodejs::instances', :type => :class do
       :instances_to_remove => [],
       :nodejs_default_path => '/usr/local/node/node-default',
       :download_timeout    => 0,
+      :install_dir         => '/usr/local/node',
     }}
 
     it { should compile.and_raise_error(/Cannot create a default instance with version/) }

--- a/spec/defines/nodejs_instance_spec.rb
+++ b/spec/defines/nodejs_instance_spec.rb
@@ -238,6 +238,24 @@ describe 'nodejs::instance', :type => :define do
       :install_dir          => '/usr/local/node',
     }}
 
+    describe 'custom source' do
+      let(:params) {{
+        :version              => 'v6.0.0',
+        :ensure               => 'present',
+        :make_install         => false,
+        :target_dir           => '/usr/local/bin',
+        :cpu_cores            => 1,
+        :default_node_version => 'v5.6.0',
+        :timeout              => 0,
+        :install_dir          => '/usr/local/node',
+        :source               => 'https://example.org/dist-nodejs'
+      }}
+
+      it { should contain_nodejs__instance__download('nodejs-download-v6.0.0') \
+        .with_source('https://example.org/dist-nodejs') \
+      }
+    end
+
     describe 'os' do
       describe 'darwin' do
         let(:facts) {{

--- a/spec/defines/nodejs_instance_spec.rb
+++ b/spec/defines/nodejs_instance_spec.rb
@@ -21,6 +21,7 @@ describe 'nodejs::instance', :type => :define do
       :cpu_cores            => 2,
       :default_node_version => nil,
       :timeout              => 0,
+      :install_dir          => '/usr/local/node',
     }}
 
     it { should contain_nodejs__instance__download('nodejs-download-v4.4.7') \
@@ -50,6 +51,7 @@ describe 'nodejs::instance', :type => :define do
       :cpu_cores            => 1,
       :default_node_version => nil,
       :timeout              => 0,
+      :install_dir          => '/usr/local/node',
     }}
 
     it { should contain_exec('nodejs-make-install-v6.2.0') \
@@ -69,6 +71,7 @@ describe 'nodejs::instance', :type => :define do
       :cpu_cores            => 2,
       :default_node_version => nil,
       :timeout              => 0,
+      :install_dir          => '/usr/local/node',
     }}
 
     it { should contain_file('nodejs-install-dir') \
@@ -141,6 +144,7 @@ describe 'nodejs::instance', :type => :define do
       :cpu_cores            => 1,
       :default_node_version => nil,
       :timeout              => 0,
+      :install_dir          => '/usr/local/node',
     }}
 
     it { should contain_exec('nodejs-make-install-v6.0.0') \
@@ -159,6 +163,7 @@ describe 'nodejs::instance', :type => :define do
       :cpu_cores            => 1,
       :default_node_version => nil,
       :timeout              => 0,
+      :install_dir          => '/usr/local/node',
     }}
 
     it { should contain_file('nodejs-symlink-bin-with-version-v6.2.0') \
@@ -177,6 +182,7 @@ describe 'nodejs::instance', :type => :define do
       :make_install         => false,
       :default_node_version => nil,
       :timeout              => 0,
+      :install_dir          => '/usr/local/node',
     }}
 
     it { should_not contain_exec('nodejs-make-install-v6.2.0') }
@@ -192,6 +198,7 @@ describe 'nodejs::instance', :type => :define do
         :cpu_cores            => 1,
         :default_node_version => 'v4.6.0',
         :timeout              => 0,
+        :install_dir          => '/usr/local/node',
       }}
 
       it { should contain_file('/usr/local/node/node-v0.12.0') \
@@ -212,6 +219,7 @@ describe 'nodejs::instance', :type => :define do
         :cpu_cores            => 1,
         :default_node_version => 'v5.6.0',
         :timeout              => 0,
+        :install_dir          => '/usr/local/node',
       }}
 
       it { should compile.and_raise_error(/Can't remove the instance/) }
@@ -227,6 +235,7 @@ describe 'nodejs::instance', :type => :define do
       :cpu_cores            => 1,
       :default_node_version => 'v5.6.0',
       :timeout              => 0,
+      :install_dir          => '/usr/local/node',
     }}
 
     describe 'os' do

--- a/spec/spec_base.rb
+++ b/spec/spec_base.rb
@@ -1,0 +1,12 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec'
+
+
+RSpec.configure do |config|
+  config.after(:suite) do
+    RSpec::Puppet::Coverage.report!
+  end
+end
+
+$:.unshift File.join(File.dirname(__FILE__),  'fixtures', 'modules', 'stdlib', 'lib')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,10 @@
-require 'rubygems'
-require 'puppetlabs_spec_helper/module_spec_helper'
+require 'spec_base'
 require 'webmock/rspec'
-require 'rspec'
+require 'coveralls'
 
-WebMock.disable_net_connect!()
+Coveralls.wear!
+
+WebMock.disable_net_connect!
 
 nodejs_response = <<JSON
 [
@@ -22,18 +23,10 @@ nodejs_response = <<JSON
 ]
 JSON
 
+
 RSpec.configure do |config|
   config.before(:each) do
     stub_request(:get, "https://nodejs.org/dist/index.json")
       .to_return(:status => 200, :body => nodejs_response, :headers => {})
   end
-
-  config.after(:suite) do
-    RSpec::Puppet::Coverage.report!
-  end
 end
-
-$:.unshift File.join(File.dirname(__FILE__),  'fixtures', 'modules', 'stdlib', 'lib')
-
-require 'coveralls'
-Coveralls.wear!

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,10 @@
+require 'spec_base'
+require 'beaker-rspec'
+require 'beaker-puppet'
+require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
+
+run_puppet_install_helper
+install_ca_certs
+install_module_on(hosts)
+install_module_dependencies_on(hosts)


### PR DESCRIPTION
This is a rather big changeset, for detailed descriptions of each change, please read the text blocks of the commit messages.

The main idea behind v2.1 is less to release a feature-rich release, but to cleanup (and deprecate) parts of the module to ease maintenance and future development. In order to achieve this, EOLed dependencies have been dropped and newer language features have been used. To allow CI to actually perform acceptance tests, beaker has been adopted.

I'll leave this PR open for some time to await feedback (and see if I actually want to have everything as-is), then I'll start to prepare 2.1 release.
