### PR TITLE
Fix local undefined variable regression.

### DIFF
--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -80,7 +80,7 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
 
   def uninstall
     options = ['--global']
-    options += join_options(resource[:uninstall_options]) if resources[:uninstall_options]
+    options += join_options(resource[:uninstall_options]) if resource[:uninstall_options]
     npm('uninstall', *options, resource[:name])
   end
 end


### PR DESCRIPTION
### Overview

Fixes a regression where a local undefined variable `resources` was referenced.

### Related issues

Fixes https://github.com/willdurand/puppet-nodejs/issues/190
