### PR TITLE
Allow puppetlabs/stdlib 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.12.0 < 6.0.0"
+      "version_requirement": ">= 4.12.0 < 7.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
### Overview

Allow puppetlabs/stdlib 6.x

### Related issues

None
