### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,6 @@ script: "rake $TARGET"
 
 sudo: false
 
+cache: bundler
+
 services: docker


### PR DESCRIPTION
Would be interested to know why bundler caching of Travis hasn't been enabled in this repository. Thank you.