### PR TITLE
Adapt necessary gcc_packages for Debian

### DIFF
--- a/manifests/instance/pkgs.pp
+++ b/manifests/instance/pkgs.pp
@@ -19,15 +19,12 @@ class nodejs::instance::pkgs(Boolean $make_install = false) {
   ensure_packages(['tar', 'wget'])
 
   if $make_install {
-    # inherited from https://github.com/puppetlabs/puppetlabs-gcc/blob/master/manifests/params.pp,
-    # but the module is abandoned and only supports Puppet3.
     $gcc_packages = $::osfamily ? {
-      'RedHat' => ['gcc', 'gcc-g++'],
-      'Debian' => ['gcc', 'build-essential'],
+      'RedHat' => ['gcc', 'gcc-g++', 'make'],
+      'Debian' => ['build-essential'],
       default  => fail("Class['::nodejs::instances::pkgs']: unsupported osfamily: ${::osfamily}")
     }
 
     ensure_packages($gcc_packages)
-    ensure_packages(['make'])
   }
 }


### PR DESCRIPTION
In Debian, the `build_essential` meta package already includes `gcc` and `make` as dependencies, so we can speed up the installation process and remove unnecessary puppet steps by only installing `build_essential` for Debian and moving the separate `make` ensure_package to the RedHat package list directly.
Debian: https://packages.debian.org/buster/build-essential

### Overview

Describe here what your PR is actually doing including information like whether you've observed possible BC breaks.

### Related issues

If your PR solves issues, they should be referenced here.
